### PR TITLE
[Misc] Improve simulator&&api_server performance

### DIFF
--- a/benchmark/benchmark_serving.py
+++ b/benchmark/benchmark_serving.py
@@ -424,7 +424,7 @@ async def benchmark(
     allow_variable_generation_length: bool,
     verbose: bool,
     results_filename: str,
-    ip_ports: list[int],
+    ip_ports: List[int],
     distribution: str,
     qps: float,
     coefficient_variation: float,

--- a/llumnix/backends/vllm/llm_engine.py
+++ b/llumnix/backends/vllm/llm_engine.py
@@ -177,9 +177,7 @@ class BackendVLLM(BackendInterface):
                                                            src_worker_handle_list=self.worker_handle_list))
 
     def step(self) -> Tuple[List[RequestOutput], InstanceInfo, List[ServerInfo]]:
-        t0_inference_begin = time.time()
         output_list = self.engine.step()
-        t1_inference_end = time.time()
 
         instance_info: InstanceInfo = self.engine.scheduler.get_record_instance_info()
 
@@ -191,7 +189,7 @@ class BackendVLLM(BackendInterface):
         instance_info.instance_id = self.instance_id
         instance_info.step_id = next(self.step_counter)
         instance_info.timestamp = time.time()
-        instance_info.latency = (t1_inference_end - t0_inference_begin)*1000
+        instance_info.latency = self.engine.model_executor.last_inference_latency
         seq_groups = self.engine.scheduler.running
         if seq_groups:
             tot_blocks = []


### PR DESCRIPTION
1. Fix typo in benchmark_serving.py.
2. Improve api server throughput.
3. Record inference latency in executor to improve simulator accuracy.
4. Fix TP hang by changing worker max_concurrency to 2. 
5. Use real profiling latency data by default(rather than estimated data) to improve simulator accuracy.