### PR TITLE
[Misc] Update instance info of engine in a timely manner

### DIFF
--- a/benchmark/benchmark_serving.py
+++ b/benchmark/benchmark_serving.py
@@ -83,7 +83,7 @@ async def query_model_vllm(prompt, verbose, ip_ports):
     global num_finished_requests
 
     async with aiohttp.ClientSession(timeout=timeout) as session:
-        # TODO(yiwang): Remove hard codes of params.
+        # TODO(s5u13b): Remove hard codes of params.
         best_of = 1
         use_beam_search = False
         output_len = expected_response_len

--- a/docs/Arguments.md
+++ b/docs/Arguments.md
@@ -37,16 +37,17 @@ usage: -m llumnix.entrypoints.vllm.api_server [-h]
             [--migration-num-layers MIGRATION_NUM_LAYERS]
             [--last-stage-max-blocks LAST_STAGE_MAX_BLOCKS]
             [--max-stages MAX_STAGES]
+
 ```
 
 `--disable-fixed-node-init-instance`
-- Disable fixing the instance's placement to the current node.
+- Disable fixing the placement of instance to current node.
 
 `--disable-init-instance-by-manager`
-- Disable the initialization of instance by the manager.
+- Disable initializing instance by manager.
 
 `--initial-instances`
-- Number of model instances created at initialization.
+- Number of instances created at initialization.
 - Default: 1
 
 `--load-metric`
@@ -56,7 +57,7 @@ usage: -m llumnix.entrypoints.vllm.api_server [-h]
 
 `--polling-interval`
 - Time interval(s) to update instance info and pair migration.
-- Default: 0.1
+- Default: 0.05
 
 `--dispatch-policy`
 - Request dispatch policy.
@@ -72,6 +73,8 @@ usage: -m llumnix.entrypoints.vllm.api_server [-h]
 
 `--pair-migration-policy`
 - Pair migration policy.
+- Possible choices: balanced, defrag_constrained, defrag_relaxed
+- Default: "defrag_constrained"
 
 `--migrate-out-threshold`
 - Migrate out instance load threshold.
@@ -104,15 +107,15 @@ usage: -m llumnix.entrypoints.vllm.api_server [-h]
 `--scaling-policy`
 - Scaling policy.
 - Possible choices: max_load, avg_load
-- default: "max_load"
+- default: "avg_load"
 
 `--scale-up-threshold`
 - Scale up threshold.
-- Default: 4
+- Default: 10
 
 `--scale-down-threshold`
 - Scale down threshold.
-- Default: 100
+- Default: 60
 
 `--disable-log-requests-manager`
 - Disable logging requests in manager.

--- a/docs/Arguments.md
+++ b/docs/Arguments.md
@@ -86,7 +86,7 @@ usage: -m llumnix.entrypoints.vllm.api_server [-h]
 - Default: "SJF"
 
 `--enable-defrag`
-- Enable defragmentation.
+- Enable defragmentation through migration based on virtual usage.
 - Default: False
 
 `--enable-scaling`

--- a/llumnix/arg_utils.py
+++ b/llumnix/arg_utils.py
@@ -145,7 +145,7 @@ class EngineManagerArgs:
         parser.add_argument('--enable-defrag',
                             type=bool,
                             default=EngineManagerArgs.enable_defrag,
-                            help='enable defragmentation')
+                            help='enable defragmentation through migration based on virtual usage')
 
         parser.add_argument('--enable-scaling',
                             action='store_true',

--- a/llumnix/arg_utils.py
+++ b/llumnix/arg_utils.py
@@ -54,7 +54,7 @@ class EngineManagerArgs:
     gpu_type: str = "a10"
     migration_backend_init_timeout: float = 10.0
     migration_backend: str = "rpc"
-    migration_cache_blocks: int = 32
+    migration_cache_blocks: int = 512
     migration_num_layers: int = 1
     last_stage_max_blocks: int = 16
     max_stages: int = 3
@@ -99,11 +99,11 @@ class EngineManagerArgs:
                             help='disable fixing the placement of instance to current node')
         parser.add_argument('--disable-init-instance-by-manager',
                             action='store_true',
-                            help='disable the initialization of the instance by the manager')
+                            help='disable initializing instance by manager')
         parser.add_argument('--initial-instances',
                             type=int,
                             default=EngineManagerArgs.initial_instances,
-                            help='number of model instances created at initialzation')
+                            help='number of instances created at initialzation')
 
         parser.add_argument('--load-metric',
                             type=str,
@@ -200,7 +200,7 @@ class EngineManagerArgs:
                             type=str,
                             default=EngineManagerArgs.migration_backend,
                             choices=['gloo','nccl','rpc'],
-                            help='communication backend during migration')
+                            help='communication backend of migration')
         parser.add_argument('--migration-backend-init-timeout',
                             type=float,
                             default=EngineManagerArgs.migration_backend_init_timeout,
@@ -208,7 +208,7 @@ class EngineManagerArgs:
         parser.add_argument('--migration-cache-blocks',
                             type=int,
                             default=EngineManagerArgs.migration_cache_blocks,
-                            help='cache blocks num during migration')
+                            help='number of cache blocks in migration')
         parser.add_argument('--migration-num-layers',
                             type=int,
                             default=EngineManagerArgs.migration_num_layers,

--- a/llumnix/backends/vllm/llm_engine.py
+++ b/llumnix/backends/vllm/llm_engine.py
@@ -146,7 +146,7 @@ class LLMEngineLlumnix(LLMEngine):
                 server_info_list.append(self.request_server_info[output.request_id])
             self._put_request_output_to_server(output_list, server_info_list)
         self.instance_info = instance_info
-    
+
     def update_instance_info(self, instance_info: InstanceInfo) -> None:
         # These fields are updated after step.
         if self.instance_info is not None:
@@ -157,8 +157,8 @@ class LLMEngineLlumnix(LLMEngine):
             instance_info.num_blocks_last_running_request = self.instance_info.num_blocks_last_running_request
         self.instance_info = instance_info
 
-    def _put_request_output_to_server(self, 
-                                      request_outputs: List[RequestOutput], 
+    def _put_request_output_to_server(self,
+                                      request_outputs: List[RequestOutput],
                                       server_infos: List[ServerInfo]) -> None:
         server_request_outputs = defaultdict(list)
         server_queue: Dict[str, RayQueue] = {}

--- a/llumnix/backends/vllm/llm_engine.py
+++ b/llumnix/backends/vllm/llm_engine.py
@@ -79,7 +79,6 @@ class LLMEngineLlumnix(LLMEngine):
             executor_class.migration_config = migration_config
         else:
             raise ValueError('unimplemented executor backend')
-        # TODO(s5u13b): Do not hack here.
         # Hack to pass node_id to _init_workers_ray function.
         executor_class.node_id = node_id
         # Create the LLM engine.

--- a/llumnix/backends/vllm/scheduler.py
+++ b/llumnix/backends/vllm/scheduler.py
@@ -62,7 +62,7 @@ class SchedulerLlumnix(Scheduler):
         self.prefilling_seq_groups = []
         self.scheduler_lock = threading.Lock()
         self.migrating_out_request_last_stage = []
-    
+
     def add_update_instance_info_callback(self, update_instance_info_callback):
         self.update_instance_info_callback = update_instance_info_callback
         self.update_instance_info_callback(self._get_instance_info())

--- a/llumnix/llm_engine_manager.py
+++ b/llumnix/llm_engine_manager.py
@@ -38,7 +38,6 @@ MANAGER_ACTOR_NAME = 'manager'
 CLEARING_INTERVAL = 3600
 RETRIES_INTERVALS = 5.0
 
-# TODO(s5u13b): add unit test for CI
 # TODO(s5u13b): Fix the logger when manager failover.
 
 
@@ -252,7 +251,6 @@ class LLMEngineManager:
                 call_migrate_instance_pairs.append(migrate_instance_pair)
                 task = self.instances[migrate_out_instance_id].migrate_out.remote(migrate_in_instance_name)
                 migration_tasks.append(task)
-            # TODO(s5u13b): It's not necessary for manager to await for each migration.
             # TODO(s5u13b): Migration failover could be implemented in Llumlet rather than manager.
             rets = await asyncio.gather(*migration_tasks, return_exceptions=True)
             await self._post_migrate(rets, call_migrate_instance_pairs)
@@ -426,7 +424,7 @@ class LLMEngineManager:
         logger.info("engine_manager_args: {}".format(engine_manager_args))
         return engine_manager
 
-    # TODO(s5u13b): significant duplication with llumlet_utils.init_llumlets. consider reducing duplicate codes.
+    # TODO(s5u13b): Significant duplication with llumlet_utils.init_llumlets. Consider reducing duplicate codes.
     def init_llumlets(self,
                       engine_args,
                       node_id: str) -> Tuple[List[str], List[Llumlet]]:

--- a/llumnix/llm_engine_manager.py
+++ b/llumnix/llm_engine_manager.py
@@ -38,8 +38,8 @@ MANAGER_ACTOR_NAME = 'manager'
 CLEARING_INTERVAL = 3600
 RETRIES_INTERVALS = 5.0
 
-# TODO(yiwang): add unit test for CI
-# TODO(yiwang): Fix the logger when manager failover.
+# TODO(s5u13b): add unit test for CI
+# TODO(s5u13b): Fix the logger when manager failover.
 
 
 class LLMEngineManager:
@@ -67,7 +67,7 @@ class LLMEngineManager:
         logger.info("num_instances: {}".format(self.num_instances))
         logger.info("max_instances: {}, min_instances: {}".format(self.max_instances, self.min_instances))
 
-        # TODO(yiwang): refactor auto-scaling
+        # TODO(s5u13b): refactor auto-scaling
 
         self.instances: Dict[str, Llumlet] = {}
         self.instance_migrating: Dict[str, bool] = {}
@@ -252,8 +252,8 @@ class LLMEngineManager:
                 call_migrate_instance_pairs.append(migrate_instance_pair)
                 task = self.instances[migrate_out_instance_id].migrate_out.remote(migrate_in_instance_name)
                 migration_tasks.append(task)
-            # TODO(yiwang): It's not necessary for manager to await for each migration.
-            # TODO(yiwang): Migration failover could be implemented in Llumlet rather than manager.
+            # TODO(s5u13b): It's not necessary for manager to await for each migration.
+            # TODO(s5u13b): Migration failover could be implemented in Llumlet rather than manager.
             rets = await asyncio.gather(*migration_tasks, return_exceptions=True)
             await self._post_migrate(rets, call_migrate_instance_pairs)
         # pylint: disable=W0703

--- a/llumnix/llm_engine_manager.py
+++ b/llumnix/llm_engine_manager.py
@@ -425,6 +425,7 @@ class LLMEngineManager:
         return engine_manager
 
     # TODO(s5u13b): Significant duplication with llumlet_utils.init_llumlets. Consider reducing duplicate codes.
+    # TODO(s5u13b): Fix the logger when enabling init instance by manager.
     def init_llumlets(self,
                       engine_args,
                       node_id: str) -> Tuple[List[str], List[Llumlet]]:


### PR DESCRIPTION
Previously, we updated the instance info of the engine after each step. Instance info is used by the global scheduler to get the instance's memory usage, etc. However, the actual time point of instance memory update occurs when the scheduler schedules the requests before each step. So, instead of updating the instance info after each step, this pr implements the scheduler to call back the engine to update instance info right after scheduling requests. With this change, the global scheduler can get more timely instance info, which could benefit dynamic scheduling.
Also, I fix some arguments description and TODOs passingly in this pr.