### PR TITLE
[Failover][BugFix] Fix duplicate requests caused by failover

### DIFF
--- a/llumnix/backends/vllm/llm_engine.py
+++ b/llumnix/backends/vllm/llm_engine.py
@@ -251,9 +251,6 @@ class BackendVLLM(BackendInterface):
                     server_info: ServerInfo,
                     *args,
                     **kwargs) -> None:
-        # When manager is unavailable, api server might dispatch the request that has already been dispatched.
-        if request_id in self.engine.request_server_info:
-            return
         # Store the server information of each request to put the request outputs back to the corresponding api server correctly.
         self.engine.request_server_info[request_id] = server_info
         self.engine.add_request(request_id, *args, **kwargs)

--- a/llumnix/entrypoints/vllm/api_server.py
+++ b/llumnix/entrypoints/vllm/api_server.py
@@ -83,13 +83,13 @@ async def manager_generate(prompt, sampling_params, request_id) -> AsyncStream:
     try:
         # await to catch exception
         await engine_manager.generate.remote(request_id, server_info, prompt, sampling_params)
-        if not manager_available:
-            manager_available = True
+        manager_available = True
     except ray.exceptions.RayActorError:
         # Do not re-generate the request to avoid duplicate requests.
         if manager_available:
             manager_available = False
             return results_generator
+
         try:
             if instance_num_requests:
                 instance_id = min(instance_num_requests, key=instance_num_requests.get)

--- a/llumnix/entrypoints/vllm/api_server.py
+++ b/llumnix/entrypoints/vllm/api_server.py
@@ -46,7 +46,7 @@ request_streams: Dict[str, AsyncStream] = {}
 log_requests = None
 num_finished_requests = 0
 WAIT_MANAGER_INTERVAL = 5
-manager_first_dead = True
+manager_available = True
 
 
 async def _background_process_outputs():
@@ -79,16 +79,16 @@ async def manager_generate(prompt, sampling_params, request_id) -> AsyncStream:
     # This request's outputs will be put to the request_output_queue of this api server no matter which instance it's running in.
     server_info = ServerInfo(server_id, request_output_queue)
     # If manager is unavailable, request will be directly added to the llumlet held by api server.
-    global manager_first_dead
+    global manager_available
     try:
         # await to catch exception
         await engine_manager.generate.remote(request_id, server_info, prompt, sampling_params)
-        if not manager_first_dead:
-            manager_first_dead = True
+        if not manager_available:
+            manager_available = True
     except ray.exceptions.RayActorError:
         # Do not re-generate the request to avoid duplicate requests.
-        if manager_first_dead:
-            manager_first_dead = False
+        if manager_available:
+            manager_available = False
             return results_generator
         try:
             if instance_num_requests:

--- a/llumnix/llm_engine_manager.py
+++ b/llumnix/llm_engine_manager.py
@@ -122,8 +122,6 @@ class LLMEngineManager:
         except (ray.exceptions.RayActorError, KeyError):
             logger.info("[generate] instance {} is dead, regenerate request {}".format(instance_id, request_id))
             self.scale_down(instance_id)
-            if self.num_instances != 0:
-                asyncio.create_task(self.generate(request_id, server_info, *args, **kwargs))
 
     async def abort(self, request_id: Union[str, Iterable[str]]) -> None:
         if isinstance(request_id, str):


### PR DESCRIPTION
Currently, when Llumnix finds manager/instance unavailable when generating a request, the request is regenerated because Llumnix cannot know whether the request is successfully dispatched into instance. However, this could bring duplicate requests in instances. Duplicate requests mean that two requests will continuously output to the user at the same time, which is quite terrible behavior. However, duplicate requests are hard to detect and intercept by api server unless comparing the output prompts of requests. But this will cause innegligible cost in the critical path of processing outputs. Considering the low possibility of manager/instance unavailable when generating a request, we choose not to re-generate the request, and user can find the request failed when timeout, which is consistent with other failover cases.