### PR TITLE
[CI] move cancel_previous_workflows to ubuntu-latest

### DIFF
--- a/.github/workflows/bench_test.yml
+++ b/.github/workflows/bench_test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   cancel_previous_workflows:
-    runs-on: [self-hosted]
+    runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
     - uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   cancel_previous_workflows:
-    runs-on: [self-hosted]
+    runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
     - uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/migration_test.yml
+++ b/.github/workflows/migration_test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   cancel_previous_workflows:
-    runs-on: [self-hosted]
+    runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
     - uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/offline_inference.yml
+++ b/.github/workflows/offline_inference.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   cancel_previous_workflows:
-    runs-on: [self-hosted]
+    runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
     - uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   cancel_previous_workflows:
-    runs-on: [self-hosted]
+    runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
     - uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   cancel_previous_workflows:
-    runs-on: [self-hosted]
+    runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
     - uses: styfle/cancel-workflow-action@0.12.1

--- a/tests/e2e_test/test_migration.py
+++ b/tests/e2e_test/test_migration.py
@@ -75,7 +75,7 @@ async def test_migration_benchmark(model, migration_backend):
         assert process.returncode == 0
 
     for i in range(device_count//2):
-        bench_command = generate_bench_command(ip_ports=f"127.0.0.1:{base_port+i}", model=model, num_prompts=500,
+        bench_command = generate_bench_command(ip_ports=f"127.0.0.1:{base_port+i}", model=model, num_prompts=300,
                                                 dataset_type="sharegpt",
                                                 dataset_path="/mnt/dataset/sharegpt_gpt4/sharegpt_gpt4.jsonl" ,
                                                 qps=10)


### PR DESCRIPTION
Previously, cancel_previous_workflows ran on self-hosted runners, but all workflows were executed in a queued manner on the self-hosted environment, which prevented cancel_previous_workflows from canceling workflows submitted on the current branch. Changing it to ubuntu-latest can resolve this issue.