### PR TITLE
[Bugfix] Change num_cpu to 0 for async_put_queue_actor

### DIFF
--- a/llumnix/backends/vllm/llm_engine.py
+++ b/llumnix/backends/vllm/llm_engine.py
@@ -114,7 +114,7 @@ class LLMEngineLlumnix(LLMEngine):
             target=self._start_put_queue_loop, args=(), daemon=True, name="put_queue_loop"
         )
         self.async_put_queue_actor = ray.remote(
-            num_cpus=1,
+            num_cpus=0,
             scheduling_strategy=scheduling_strategy
         )(AsyncPutQueueActor).remote(instance_id, output_queue_type)
         self.put_queue_loop_thread.start()

--- a/llumnix/entrypoints/vllm/api_server.py
+++ b/llumnix/entrypoints/vllm/api_server.py
@@ -303,7 +303,7 @@ if __name__ == "__main__":
 
     cli_args = parser.parse_args()
     cfg: LlumnixConfig = get_llumnix_config(cli_args.config_file, cli_args)
-    
+
     engine_manager_args = EngineManagerArgs.from_llumnix_config(cfg)
     EngineManagerArgs.check_args(engine_manager_args, parser)
     engine_args = AsyncEngineArgs.from_cli_args(cli_args)

--- a/llumnix/entrypoints/vllm/api_server.py
+++ b/llumnix/entrypoints/vllm/api_server.py
@@ -273,7 +273,7 @@ class LlumnixArgumentParser(argparse.ArgumentParser):
     def add_argument(self, *args, **kwargs):
         if self.cur_namespace == 'llumnix' and "--help" not in args:
             assert 'default' not in kwargs or kwargs['default'] is None, \
-                f"Do not set the default value for '{args[0]}' in CLI, or default value it to None. " \
+                f"Do not set the default value for '{args[0]}' in CLI, or set default value to None. " \
                 f"The default value will be retrieved from config/default.py in get_llumnix_config."
 
             if kwargs.get('action') == 'store_true':

--- a/llumnix/entrypoints/vllm/api_server.py
+++ b/llumnix/entrypoints/vllm/api_server.py
@@ -273,8 +273,12 @@ class LlumnixArgumentParser(argparse.ArgumentParser):
     def add_argument(self, *args, **kwargs):
         if self.cur_namespace == 'llumnix' and "--help" not in args:
             assert 'default' not in kwargs or kwargs['default'] is None, \
-                f"Do not set the default value for '{args[0]}' in CLI, or set it to None. " \
+                f"Do not set the default value for '{args[0]}' in CLI, or default value it to None. " \
                 f"The default value will be retrieved from config/default.py in get_llumnix_config."
+
+            if kwargs.get('action') == 'store_true':
+                kwargs['default'] = None
+
         super().add_argument(*args, **kwargs)
 
 if __name__ == "__main__":
@@ -290,7 +294,6 @@ if __name__ == "__main__":
     parser.add_argument('--launch-ray-cluster', action='store_true', help='if launch ray cluster in api server')
     parser.add_argument("--queue-type", type=str, choices=['rayqueue', 'zmq'], help='queue type for request output queue')
     parser.add_argument("--request-output-queue-port", type=int, help='port for zmq')
-    # TODO(KuilongCui): Fix default.py cannot take effects to cli arguments of action type.
     parser.add_argument("--log-request-timestamps", action='store_true', help='if log request timestamps')
     parser.add_argument("--config-file", help="path to config file")
     parser = EngineManagerArgs.add_cli_args(parser)
@@ -300,6 +303,7 @@ if __name__ == "__main__":
 
     cli_args = parser.parse_args()
     cfg: LlumnixConfig = get_llumnix_config(cli_args.config_file, cli_args)
+    
     engine_manager_args = EngineManagerArgs.from_llumnix_config(cfg)
     EngineManagerArgs.check_args(engine_manager_args, parser)
     engine_args = AsyncEngineArgs.from_cli_args(cli_args)


### PR DESCRIPTION
1. Default value cannot take effect for CLI parameters with store_true
2. change num_cpu to 0 for async_put_queue_actor as the pg for llumlet. only has 1 cpu