### PR TITLE
[Fix][Misc] vllm simulator&&migration 

### DIFF
--- a/llumnix/backends/vllm/simulator.py
+++ b/llumnix/backends/vllm/simulator.py
@@ -21,7 +21,7 @@ from vllm.engine.arg_utils import EngineArgs
 from llumnix.logger import init_logger
 from llumnix.internal_config import MigrationConfig
 from llumnix.backends.vllm.scheduler import SchedulerLlumnix
-from llumnix.backends.vllm.llm_engine import LLMEngineLlumnix, BackendVLLM
+from llumnix.backends.vllm.llm_engine import LLMEngineLlumnix, BackendVLLM, EngineState
 from llumnix.backends.profiling import ProfilingDatabase, LatencyMemData, ProfilingResult, SimParallelConfig
 from llumnix.queue.queue_type import QueueType
 
@@ -37,6 +37,29 @@ class BackendSimVLLM(BackendVLLM):
         profiling_result_file_path: str,
         engine_args: EngineArgs,
     ) -> None:
+        # multi-instance args
+        latency_mem = self._get_lantecy_mem(profiling_result_file_path)
+        self.engine: LLMEngineLlumnix = LLMEngineLlumnix.from_engine_args(engine_args=engine_args,
+                                                                          output_queue_type=output_queue_type,
+                                                                          migration_config=migration_config,
+                                                                          instance_id=instance_id,
+                                                                          latency_mem=latency_mem)
+        self.engine.scheduler = SchedulerLlumnix(self.engine.scheduler_config, self.engine.cache_config, self.engine.lora_config)
+        self.engine.scheduler.add_update_instance_info_callback(self.engine.update_instance_info)
+        self.engine.output_processor.scheduler = self.engine.scheduler
+        self.instance_id = instance_id
+
+        self.state_lock = threading.Lock()
+        self.state = EngineState.INIT
+        logger.info("engine ({}) current state {}".format(self.instance_id, self.state))
+
+        self._stop_event = threading.Event()
+        self.engine_step_loop_thread = threading.Thread(
+            target=self._start_engine_step_loop, args=(), daemon=True, name="engine_step_loop"
+        )
+        self.engine_step_loop_thread.start()
+
+    def _get_lantecy_mem(self, profiling_result_file_path: str, engine_args: EngineArgs) -> LatencyMemData:
         # load database
         profiling_database = ProfilingDatabase(profiling_result_file_path)
         engine_config = engine_args.create_engine_config()
@@ -54,20 +77,7 @@ class BackendSimVLLM(BackendVLLM):
                                                 parallel_config.pipeline_parallel_size)
         assert sim_parallel_config in profiling_result.para_dict.keys(), "sim parallel config not in database"
         latency_mem: LatencyMemData = profiling_result.para_dict[sim_parallel_config]
-        # multi-instance args
-        self.engine: LLMEngineLlumnix = LLMEngineLlumnix.from_engine_args(engine_args=engine_args,
-                                                                          output_queue_type=output_queue_type,
-                                                                          migration_config=migration_config,
-                                                                          instance_id=instance_id,
-                                                                          latency_mem=latency_mem)
-        self.engine.scheduler = SchedulerLlumnix(self.engine.scheduler_config, self.engine.cache_config, self.engine.lora_config)
-        self.engine.scheduler.add_update_instance_info_callback(self.engine.update_instance_info)
-        self.engine.output_processor.scheduler = self.engine.scheduler
-        self.instance_id = instance_id
-        self.engine_step_loop_thread = threading.Thread(
-            target=self._start_engine_step_loop, args=(), daemon=True, name="engine_loop"
-        )
-        self.engine_step_loop_thread.start()
+        return latency_mem
 
     # pylint: disable=unused-argument
     def send_blocks(self, dst_ray_actor: ray.actor.ActorHandle, src_blocks: List[int], dst_blocks: List[int]) -> None:

--- a/llumnix/llumlet/migration_coordinator.py
+++ b/llumnix/llumlet/migration_coordinator.py
@@ -26,13 +26,17 @@ logger = init_logger(__name__)
 class MigrationStatus(enum.Enum):
     """Status of Migration."""
     RUNNING = enum.auto()
-    FINISHED_ABORTED = enum.auto()
+    # aborted by src instance
+    FINISHED_ABORTED_SRC = enum.auto()
+    # aborted by dst instance
+    FINISHED_ABORTED_DST = enum.auto()
     FINISHED_DONE = enum.auto()
 
     @staticmethod
     def is_finished(status: "MigrationStatus") -> bool:
         return status in [
-            MigrationStatus.FINISHED_ABORTED,
+            MigrationStatus.FINISHED_ABORTED_SRC,
+            MigrationStatus.FINISHED_ABORTED_DST,
             MigrationStatus.FINISHED_DONE
         ]
 
@@ -73,7 +77,7 @@ class MigrationCoordinator:
             if is_last_stage:
                 self.backend_engine.add_running_request(migrate_out_request)
                 self.backend_engine.remove_migrating_out_request_last_stage(migrate_out_request)
-            migration_status = MigrationStatus.FINISHED_ABORTED
+            migration_status = MigrationStatus.FINISHED_ABORTED_DST
             return migration_status
         # do stage send/recv
         migrate_out_request.stage_timestamps.append(time.time())
@@ -82,7 +86,7 @@ class MigrationCoordinator:
         self.backend_engine.send_blocks(migrate_in_ray_actor, src_blocks, dst_blocks)
         if not is_last_stage and migrate_out_request.should_abort_migration():
             # migrate-out request abort by scheduler during send/recv
-            migration_status = MigrationStatus.FINISHED_ABORTED
+            migration_status = MigrationStatus.FINISHED_ABORTED_SRC
 
         return migration_status
 
@@ -98,7 +102,7 @@ class MigrationCoordinator:
             if MigrationStatus.is_finished(status):
                 return status
         # exceed max stages
-        return MigrationStatus.FINISHED_ABORTED
+        return MigrationStatus.FINISHED_ABORTED_SRC
 
     def migrate_in_pre_alloc(self, request_id: str, block_num: int) -> List[int]:
         """prev alloc blocks to migrate in request

--- a/llumnix/llumlet/request.py
+++ b/llumnix/llumlet/request.py
@@ -34,6 +34,9 @@ class LlumnixRequest:
         self.stage_timestamps = []
         self.stage_num_blocks_list = []
 
+    def is_finished(self) -> bool:
+        raise NotImplementedError
+
     @property
     def inference_type(self) -> RequestInferenceType:
         raise NotImplementedError
@@ -53,4 +56,5 @@ class LlumnixRequest:
     def should_abort_migration(self) -> bool:
         return self.output_len == 0 \
             or (self.last_preemption_time and self.last_preemption_time > self.stage_timestamps[-1]) \
-            or self.inference_type == RequestInferenceType.PREFILL
+            or self.inference_type == RequestInferenceType.PREFILL \
+            or self.is_finished()

--- a/tests/unit_test/backends/vllm/test_simulator.py
+++ b/tests/unit_test/backends/vllm/test_simulator.py
@@ -1,10 +1,29 @@
-from vllm import EngineArgs
+import asyncio
+import pytest
+import ray
+
+from vllm import EngineArgs, SamplingParams
+from vllm.utils import random_uuid
 from vllm.sequence import ExecuteModelRequest
 
 from llumnix.backends.vllm.executor import SimGPUExecutor
+from llumnix.backends.vllm.simulator import BackendSimVLLM
 from llumnix.backends.profiling import LatencyMemData
-from .utils import create_dummy_prompt, initialize_scheduler
+from llumnix.internal_config import MigrationConfig
+from llumnix.queue.queue_type import QueueType
 
+# pylint: disable=unused-import
+from tests.conftest import setup_ray_env
+from tests.unit_test.queue.utils import request_output_queue_server
+
+from .utils import create_dummy_prompt, initialize_scheduler
+class MockBackendSim(BackendSimVLLM):
+
+    def _get_lantecy_mem(self, *args, **kwargs):
+        latency_mem = LatencyMemData({}, {}, {})
+        latency_mem.prefill_model_params = (0,0)
+        latency_mem.decode_model_params = (0,0,0)
+        return latency_mem
 
 def test_executor():
     engine_args = EngineArgs(model="facebook/opt-125m", worker_use_ray=True)
@@ -45,7 +64,45 @@ def test_executor():
     outputs = executor.execute_model(execute_model_req)
     assert len(outputs[0].outputs) == 2
 
-def test_backend():
+@pytest.mark.asyncio
+async def test_backend(setup_ray_env):
     # TODO(ZeldaHuang): add tests for BackendSimVLLM methods
     # (currently BackendSimVLLM is just a wrapper of BackendVLLM)
-    pass
+    engine_args = EngineArgs(model="facebook/opt-125m", worker_use_ray=True)
+    migration_config = MigrationConfig("LCFS", "gloo", 16, 1, 4, 5, 20)
+
+    output_queue_type = QueueType.RAYQUEUE
+    que, server_info = request_output_queue_server(output_queue_type)
+    asyncio.create_task(que.run_server_loop())
+    class DummyActor:
+        def __init__(self):
+            pass
+    dummy_actor = ray.remote(num_cpus=1,
+                                name="instance_0",
+                                namespace='llumnix',
+                                max_concurrency=4)(DummyActor)
+    dummy_actor = dummy_actor.remote()
+    sim_backend = MockBackendSim(instance_id="0",
+                                 output_queue_type=output_queue_type,
+                                 migration_config=migration_config,
+                                 profiling_result_file_path="",
+                                 engine_args=engine_args)
+
+    sampling_params = SamplingParams(top_k=1, temperature=0, ignore_eos=True, max_tokens=100)
+    request_id0 = random_uuid()
+    sim_backend.add_request(request_id0, server_info, "hello world", sampling_params)
+
+    async def check_output_len():
+        request_output_queue = que
+        finished = False
+        output = None
+        while not finished:
+            request_outputs = await request_output_queue.get()
+            for request_output in request_outputs:
+                output = request_output.outputs[0]
+                finished = request_output.finished
+        assert output is not None and len(output.token_ids)==100
+
+    await check_output_len()
+
+    que.cleanup()

--- a/tests/unit_test/llumlet/test_local_migration_scheduler.py
+++ b/tests/unit_test/llumlet/test_local_migration_scheduler.py
@@ -20,6 +20,9 @@ class MockRequest(LlumnixRequest):
         self.length = length
         self.status = RequestInferenceType.DECODE
 
+    def is_finished(self) -> bool:
+        return False
+
     @property
     def inference_type(self) -> RequestInferenceType:
         return self.status

--- a/tests/unit_test/llumlet/test_migration_coordinator.py
+++ b/tests/unit_test/llumlet/test_migration_coordinator.py
@@ -65,7 +65,7 @@ def test_migrate_out_onestage(setup_ray_env):
     migrate_out_request.should_abort_migration.return_value = False
     migrate_in_ray_actor.execute_migration_method.remote.return_value = ray_remote_call.remote(dst_blocks)
     status = coordinator.migrate_out_onestage(migrate_in_ray_actor, migrate_out_request)
-    assert status == MigrationStatus.FINISHED_ABORTED
+    assert status == MigrationStatus.FINISHED_ABORTED_DST
 
     migrate_out_request = MagicMock()
     src_blocks = [1, 2, 3]
@@ -74,7 +74,7 @@ def test_migrate_out_onestage(setup_ray_env):
     migrate_out_request.should_abort_migration.return_value = True
     migrate_in_ray_actor.execute_migration_method.remote.return_value = ray_remote_call.remote(dst_blocks)
     status = coordinator.migrate_out_onestage(migrate_in_ray_actor, migrate_out_request)
-    assert status == MigrationStatus.FINISHED_ABORTED
+    assert status == MigrationStatus.FINISHED_ABORTED_SRC
 
 # setup_ray_env should be passed after migrate_out_onestage
 @patch.object(MigrationCoordinator, 'migrate_out_onestage')
@@ -104,4 +104,4 @@ def test_migrate_out_multistage(_, setup_ray_env):
                                                     MigrationStatus.RUNNING]
     status = coordinator.migrate_out_multistage(migrate_in_ray_actor, migrate_out_request)
     assert coordinator.migrate_out_onestage.call_count == max_stages + 1
-    assert status == MigrationStatus.FINISHED_ABORTED
+    assert status == MigrationStatus.FINISHED_ABORTED_SRC


### PR DESCRIPTION
1. Add vllm simulator backend unit test.
2. Fix `BackendSimVLLM` init bugs.
3. Add is_finished() in `LLumnixRequest`.
4. Spilt `MigrationStatus.FINISHED_ABORTED` to  `MigrationStatus.FINISHED_ABORTED_SRC` and `MigrationStatus.FINISHED_ABORTED_DST`, we can figure out the migration is aborted by src or dst instance.