### PR TITLE
[Core] Increase the instance type when scaling up llumlet

### DIFF
--- a/.github/workflows/correctness_test.yml
+++ b/.github/workflows/correctness_test.yml
@@ -1,4 +1,4 @@
-name: e2e_test
+name: correctness_test
 
 on:
   pull_request:
@@ -17,7 +17,7 @@ jobs:
       with:
         all_but_latest: true
 
-  e2e_tests:
+  correctness_tests:
     needs: cancel_previous_workflows
     runs-on: [self-hosted]
     timeout-minutes: 30
@@ -28,4 +28,4 @@ jobs:
       run: |
         [[ -n $(docker ps -q) ]] && docker kill $(docker ps -q) || echo "No running containers to kill."
     - name: Build And Test
-      run: ./tools/run_test.sh e2e_test
+      run: ./tools/run_test.sh correctness_test

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ proto-clean:
 test: check_pytest_installed
 	@pytest -v --ignore=third_party --ignore=tests/e2e_test --disable-warnings
 	@python examlpes/offline_inference.py
-	@pytest -v -x -s --tb=long ./tests/e2e_test/test_e2e.py
+	@pytest -v -x -s --tb=long ./tests/e2e_test/test_correctness.py
 	@pytest -v -x -s --tb=long ./tests/e2e_test/test_bench.py
 	@pytest -v -x -s --tb=long ./tests/e2e_test/test_migration.py
 
@@ -67,9 +67,9 @@ unit_test: check_pytest_installed
 offline_test:
 	@python examlpes/offline_inference.py
 
-.PHONY: e2e_test
-e2e_test:
-	@pytest -v -x -s --tb=long ./tests/e2e_test/test_e2e.py
+.PHONY: correctness_test
+correctness_test:
+	@pytest -v -x -s --tb=long ./tests/e2e_test/test_correctness.py
 
 .PHONY: bench_test
 bench_test:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Efficient and easy <i>multi-instance</i> LLM serving
 
 ## 🔥 Latest News
 
-- [2025.1] We updated vLLM to version v0.6.3.post1
+- [2025.1] We updated vLLM to version v0.6.3.post1.
 - [2024.11] Llumnix v0.1.0 launched!
 - [2024.7] We officially released the first version of Llumnix.
 - [2024.6] We released our OSDI '24 [research paper](https://arxiv.org/abs/2406.03243) on arxiv.

--- a/docs/Arguments.md
+++ b/docs/Arguments.md
@@ -20,7 +20,9 @@ usage: -m llumnix.entrypoints.vllm.api_server [-h]
             [--log-request-timestamps]
             [--config-file CONFIG_FILE]
             [--initial-instances INITIAL_INSTANCES]
-            [--load-metric {remaining_steps,usage_ratio}]
+            [--dispatch-load-metric {remaining_steps,usage_ratio}]
+            [--migration-load-metric {remaining_steps,usage_ratio}]
+            [--scaling-load-metric {remaining_steps,usage_ratio}]
             [--polling-interval POLLING_INTERVAL]
             [--dispatch-policy {balanced,load,queue,rr}]
             [--enable-migration]
@@ -49,12 +51,14 @@ usage: -m llumnix.entrypoints.vllm.api_server [-h]
             [--migration-backend-transfer-type {cuda_ipc,rdma,}]
             [--grpc-migration-backend-server-address GRPC_MIGRATION_BACKEND_SERVER_ADDRESS]
             [--kvtransfer-migration-backend-naming-url KVTRANSFER_MIGRATION_BACKEND_NAMING_URL]
-            [--max-stages MAX_STAGES]
-            [--last-stage-max-blocks LAST_STAGE_MAX_BLOCKS]
+            [--migration-max-stages MIGRATION_MAX_STAGES]
+            [--migration-last-stage-max-blocks MIGRATION_LAST_STAGE_MAX_BLOCKS]
             [--enable-pd-disagg]
-            [--num-dispatch-instances NUM_DISPATCH_INSTANCES]
+            [--pd-ratio PD_RATIO]
             [--enable-port-increment]
             [--enable-port-offset-store]
+            [--instance-type INSTANCE_TYPE]
+
 ```
 
 `--host`
@@ -111,8 +115,18 @@ usage: -m llumnix.entrypoints.vllm.api_server [-h]
 - Number of instances created at initialization.
 - Default: 1
 
-`--load-metric`
-- Instance load metric.
+`--dispatch-load-metric`
+- Instance dispatch load metric.
+- Possible choices: remaining_steps, usage_ratio
+- Default: "remaining_steps"
+
+`--migration-load-metric`
+- Instance migration load metric.
+- Possible choices: remaining_steps, usage_ratio
+- Default: "remaining_steps"
+
+`--scaling-load-metric`
+- Instance scaling load metric.
 - Possible choices: remaining_steps, usage_ratio
 - Default: "remaining_steps"
 
@@ -224,26 +238,30 @@ usage: -m llumnix.entrypoints.vllm.api_server [-h]
 - URL of naming server for kvtransfer migration backend
 - Default: "file:/tmp/llumnix/naming/"
 
-`--max-stages`
-- Drop migration if the number of stages > max_stages.
+`--migration-max-stages`
+- Drop migration if the number of stages > migration_max_stages.
 - Default: 3
 
-`--last-stage-max-blocks`
-- If the number of remaining blocks < last_stage_max_blocks, do last stage migration.
+`--migration-last-stage-max-blocks`
+- If the number of remaining blocks < migration_last_stage_max_blocks, do last stage migration.
 - Default: 16
 
 `--enable-pd-disagg`
 - Enable prefill decoding disaggregation.
 
-`--num-dispatch-instances`
-- Number of available instances for dispatch.
-- Default: math.inf
+`--pd-ratio`
+- The p:d ratio used in gloabl launch model.
+- Default: "1:1"
 
 `--enable-port-increment`
 - Enable port increment when desploying multiple servers.
 
 `--enable-port-offset-store`
 - Enable store port offset when desploying multiple servers.
+
+`--instance-type`
+- Instance types for the engine.
+- Possible choices: prefill, decode, no_constraints
 
 # Unsupported vLLM feature options
 

--- a/examlpes/offline_inference.py
+++ b/examlpes/offline_inference.py
@@ -5,7 +5,7 @@ import asyncio
 import ray
 
 from llumnix import launch_ray_cluster, connect_to_ray_cluster, init_manager
-from llumnix import (ManagerArgs, EngineArgs, Manager,
+from llumnix import (ManagerArgs, InstanceArgs, EngineArgs, Manager,
                      Llumlet, ServerInfo, QueueType, BackendType,
                      SamplingParams)
 from llumnix.utils import random_uuid
@@ -35,6 +35,7 @@ connect_to_ray_cluster(port=ray_cluster_port)
 
 # Set manager args and engine args.
 manager_args = ManagerArgs()
+instance_args = InstanceArgs()
 engine_args = EngineArgs(model="facebook/opt-125m", worker_use_ray=True,
                          trust_remote_code=True, max_model_len=370)
 
@@ -45,7 +46,8 @@ ray.get(manager.is_ready.remote())
 # Create instances.
 instance_ids: List[str] = None
 instances: List[Llumlet] = None
-instance_ids, instances = ray.get(manager.init_instances.remote(QueueType("rayqueue"), BackendType.VLLM, engine_args))
+instance_ids, instances = ray.get(manager.init_instances.remote(
+    QueueType("rayqueue"), BackendType.VLLM, instance_args, engine_args))
 
 # The requests‘ outputs will be put to the request_output_queue no matter which instance it's running in.
 server_id = random_uuid()

--- a/llumnix/__init__.py
+++ b/llumnix/__init__.py
@@ -15,7 +15,7 @@ from llumnix.server_info import ServerInfo
 from llumnix.entrypoints.setup import (launch_ray_cluster,
                                        connect_to_ray_cluster,
                                        init_manager)
-from llumnix.arg_utils import ManagerArgs
+from llumnix.arg_utils import ManagerArgs, InstanceArgs
 from llumnix.manager import Manager
 from llumnix.llumlet.llumlet import Llumlet
 from llumnix.queue.queue_type import QueueType
@@ -29,6 +29,7 @@ __all__ = [
     "connect_to_ray_cluster",
     "init_manager",
     "ManagerArgs",
+    "InstanceArgs",
     "Manager",
     "Llumlet",
     "QueueType",

--- a/llumnix/arg_utils.py
+++ b/llumnix/arg_utils.py
@@ -16,7 +16,7 @@
 import dataclasses
 from dataclasses import dataclass
 import argparse
-from typing import Tuple
+from typing import List, Tuple, Union
 
 from llumnix.internal_config import GlobalSchedulerConfig, MigrationConfig
 from llumnix.config import LlumnixConfig, get_llumnix_config
@@ -41,9 +41,6 @@ class LlumnixArgumentParser(argparse.ArgumentParser):
             if kwargs.get('action') == 'store_true':
                 kwargs['default'] = None
         super().add_argument(*args, **kwargs)
-
-
-# All the default values of llumnix arguments are set in default.py. So all the arguments here are set to None.
 
 @dataclass
 class EntrypointsArgs:
@@ -71,9 +68,10 @@ class EntrypointsArgs:
     def from_llumnix_config(cls, cfg: LlumnixConfig = get_llumnix_config()) -> 'EntrypointsArgs':
         # Get the list of attributes of this dataclass.
         attrs = [attr.name for attr in dataclasses.fields(cls)]
+        cfg_attrs = [attr for attr in attrs if hasattr(cfg.SERVER, attr.upper())]
         # Set the attributes from the parsed arguments.
         # The defalut values of attributes are defined in default.py.
-        entrypoints_args = cls(**{attr: getattr(cfg.SERVER, attr.upper()) for attr in attrs})
+        entrypoints_args = cls(**{attr: getattr(cfg.SERVER, attr.upper()) for attr in cfg_attrs})
         return entrypoints_args
 
     @classmethod
@@ -110,24 +108,20 @@ class EntrypointsArgs:
         parser.add_argument("--config-file",
                             type=str,
                             help="path to config file of arguments")
-
         return parser
 
 @dataclass
 class ManagerArgs:
     initial_instances: int = None
 
-    load_metric: str = None
     polling_interval: float = None
-
     dispatch_policy: str = None
+    scaling_load_metric: str = None
 
     enable_migration: bool = None
-    enable_defrag: bool = None
     pair_migration_frequency: int = None
     pair_migration_policy: str = None
     migrate_out_threshold: float = None
-    request_migration_policy: str = None
 
     enable_scaling: bool = None
     min_instances: int = None
@@ -140,25 +134,15 @@ class ManagerArgs:
     disable_log_requests_manager: bool = None
     log_instance_info: bool = None
     log_filename: str = None
-    simulator_mode: bool = None
-    profiling_result_file_path: str = None
-
-    migration_backend: str = None
-    migration_buffer_blocks: int = None
-    migration_num_layers: int = None
-    migration_backend_init_timeout: float = None
-    migration_backend_transfer_type: str = None
-    grpc_migration_backend_server_address: str = None
-    kvtransfer_migration_backend_naming_url: str = None
-    last_stage_max_blocks: int = None
-    max_stages: int = None
-
-    enable_pd_disagg: bool = None
-    num_dispatch_instances: int = None
-
     enable_port_increment: bool = None
     enable_port_offset_store: bool = None
 
+    enable_pd_disagg: bool = None
+    pd_ratio: Union[str, List[int]] = None
+
+    # init from instance args
+    is_group_kind_migration_backend: bool = None
+    enable_engine_pd_disagg: bool = None
 
     def __post_init__(self):
         # Check if all fields default to None
@@ -168,47 +152,44 @@ class ManagerArgs:
 
         for attr in dataclasses.fields(self):
             if getattr(self, attr.name) is None:
-                setattr(self, attr.name, getattr(_C.MANAGER, attr.name.upper()))
+                if hasattr(_C.MANAGER, attr.name.upper()):
+                    setattr(self, attr.name, getattr(_C.MANAGER, attr.name.upper()))
 
-    def create_global_scheduler_config(
-        self,
-    ) -> Tuple[GlobalSchedulerConfig]:
+        def parse_ratio(ratio_str):
+            parts = ratio_str.split(':')
+            if len(parts) != 2:
+                raise ValueError(f"Invalid format for --pd-ratio : '{ratio_str}'. Expected format 'a:b'.")
+            num_prefill, num_decode = int(parts[0].strip()), int(parts[1].strip())
+            assert num_prefill > 0 and num_decode > 0, "Both parts of --pd-ratio must be non-negative."
+            return [num_prefill, num_decode]
+        self.pd_ratio = parse_ratio(self.pd_ratio)
 
+    def init_from_instance_args(self, instance_args: 'InstanceArgs'):
+        self.enable_engine_pd_disagg = instance_args.enable_engine_pd_disagg
+        self.is_group_kind_migration_backend = instance_args.migration_backend in ['gloo', 'nccl']
+
+    def create_global_scheduler_config(self, is_group_kind_migration_backend) -> Tuple[GlobalSchedulerConfig]:
         # Create the GlobalScheduler Configuration.
         global_scheduler_config = GlobalSchedulerConfig(self.initial_instances,
-                                                        self.load_metric,
                                                         self.dispatch_policy,
-                                                        self.num_dispatch_instances,
                                                         self.pair_migration_policy,
                                                         self.migrate_out_threshold,
-                                                        self.enable_defrag,
                                                         self.scaling_policy,
+                                                        self.scaling_load_metric,
                                                         self.scale_up_threshold,
                                                         self.scale_down_threshold,
                                                         self.enable_pd_disagg,
-                                                        self.migration_backend)
+                                                        is_group_kind_migration_backend)
         return global_scheduler_config
-
-    def create_migration_config(self) -> MigrationConfig:
-        migration_config = MigrationConfig(self.request_migration_policy,
-                                           self.migration_backend,
-                                           self.migration_buffer_blocks,
-                                           self.migration_num_layers,
-                                           self.last_stage_max_blocks,
-                                           self.max_stages,
-                                           self.migration_backend_init_timeout,
-                                           self.migration_backend_transfer_type,
-                                           self.grpc_migration_backend_server_address,
-                                           self.kvtransfer_migration_backend_naming_url)
-        return migration_config
 
     @classmethod
     def from_llumnix_config(cls, cfg: LlumnixConfig = get_llumnix_config()) -> 'ManagerArgs':
         # Get the list of attributes of this dataclass.
         attrs = [attr.name for attr in dataclasses.fields(cls)]
+        cfg_attrs = [attr for attr in attrs if hasattr(cfg.MANAGER, attr.upper())]
         # Set the attributes from the parsed arguments.
         # The defalut values of attributes are defined in default.py.
-        manager_args = cls(**{attr: getattr(cfg.MANAGER, attr.upper()) for attr in attrs})
+        manager_args = cls(**{attr: getattr(cfg.MANAGER, attr.upper()) for attr in cfg_attrs})
         return manager_args
 
     @classmethod
@@ -219,15 +200,6 @@ class ManagerArgs:
                 cur_arg = getattr(args, action.dest)
                 assert cur_arg in action.choices, f"{action.dest} should be one of {action.choices}, but {cur_arg} is set."
 
-        # bladellm only
-        assert args.migration_backend not in ['kvtransfer'] or (args.migration_backend == 'kvtransfer' \
-            and args.migration_backend_transfer_type), \
-            ("When using kvTransfer as migration backend, "
-             "do not set --migration-backend-transfer-type as empty.")
-
-        assert not args.simulator_mode or args.profiling_result_file_path is not None, \
-            "Set profiling_result_file_path args when enable simulator mode"
-
         assert not args.enable_port_offset_store or args.enable_port_increment, \
             "Set enable_port_increment when enable_port_offset_store"
 
@@ -236,15 +208,13 @@ class ManagerArgs:
         parser.add_argument('--initial-instances',
                             type=int,
                             help='number of instances created at initialzation')
-
-        parser.add_argument('--load-metric',
-                            type=str,
-                            choices=['remaining_steps', 'usage_ratio'],
-                            help='instance load metric')
         parser.add_argument('--polling-interval',
                             type=float,
                             help='time interval(s) to update instance info and pair migration')
-
+        parser.add_argument('--scaling-load-metric',
+                            type=str,
+                            choices=['remaining_steps', 'usage_ratio'],
+                            help='instance scaling load metric')
         parser.add_argument('--dispatch-policy',
                             type=str,
                             choices=['balanced', 'load', 'queue', 'flood', 'rr'],
@@ -254,13 +224,9 @@ class ManagerArgs:
                             '* "queue" dispatch request to the instance with minimum waiting request queue length.\n'
                             '* "flood" dispatch request to the instance with maximum requests dispatched.\n'
                             '* "rr" dispatch requests with round-robin policy.\n')
-
         parser.add_argument('--enable-migration',
                             action='store_true',
                             help='enable migrate requests between instances')
-        parser.add_argument('--enable-defrag',
-                            type=bool,
-                            help='enable defragmentation through migration based on virtual usage')
         parser.add_argument('--pair-migration-frequency',
                             type=int,
                             help='pair migration frequency')
@@ -276,17 +242,6 @@ class ManagerArgs:
         parser.add_argument('--migrate-out-threshold',
                             type=float,
                             help='migrate out instance load threshold')
-        parser.add_argument('--request-migration-policy',
-                            type=str,
-                            default=None,
-                            choices=['LCR', 'SR', 'LR', 'FCW', 'FCWSR'],
-                            help='The request migration policy.\n\n'
-                            '* "LCR" migrate the running request last come.\n'
-                            '* "SR" migrate the running request shortest.\n'
-                            '* "LR" migrate the running request longest.\n'
-                            '* "FCW" migrate the waiting request first come.\n'
-                            '* "FCWSR" migrate the waiting request first come and running request shortest.\n')
-
         parser.add_argument('--enable-scaling',
                             action='store_true',
                             help='enable auto scaling')
@@ -309,7 +264,6 @@ class ManagerArgs:
         parser.add_argument('--scale-down-threshold',
                             type=float,
                             help='scale down threshold')
-
         parser.add_argument('--disable-log-requests-manager',
                             action='store_true',
                             help='disable logging requests in manager')
@@ -319,12 +273,152 @@ class ManagerArgs:
         parser.add_argument('--log-filename',
                             type=str,
                             help='log filename')
+        parser.add_argument('--enable-port-increment',
+                            action='store_true',
+                            help='enable port increment when desploying multiple servers')
+        parser.add_argument('--enable-port-offset-store',
+                            action='store_true',
+                            help='enable store port offset when desploying multiple servers')
+        parser.add_argument('--enable-pd-disagg',
+                            action='store_true',
+                            help='enable prefill decoding disaggregation')
+        parser.add_argument('--pd-ratio',
+                            type=str,
+                            help='the prefill decode ratio used in gloabl launch model e.g. "1:1"')
+        return parser
+
+@dataclass
+class LaunchArgs:
+    launch_mode: LaunchMode = None
+    backend_type: BackendType = None
+
+@dataclass
+class InstanceArgs:
+    instance_type: str = None
+
+    simulator_mode: bool = None
+    profiling_result_file_path: str = None
+
+    dispatch_load_metric: str = None
+    migration_load_metric: str = None
+    enable_defrag: bool = None
+
+    request_migration_policy: str = None
+
+    migration_backend: str = None
+    migration_buffer_blocks: int = None
+    migration_num_layers: int = None
+    migration_backend_init_timeout: float = None
+    migration_backend_transfer_type: str = None
+    grpc_migration_backend_server_address: str = None
+    kvtransfer_migration_backend_naming_url: str = None
+    migration_last_stage_max_blocks: int = None
+    migration_max_stages: int = None
+
+    # init from engine args
+    enable_engine_pd_disagg: bool = None
+
+    def __post_init__(self):
+        # Check if all fields default to None
+        for field_info in dataclasses.fields(self):
+            if field_info.default is not None:
+                raise ValueError(f"The default value of '{field_info.name}' should be None")
+
+        for attr in dataclasses.fields(self):
+            if getattr(self, attr.name) is None:
+                if hasattr(_C.INSTANCE, attr.name.upper()):
+                    setattr(self, attr.name, getattr(_C.INSTANCE, attr.name.upper()))
+
+    def init_from_engine_args(self, engine_args, backend_type: BackendType):
+        if backend_type == BackendType.BLADELLM:
+            self.enable_engine_pd_disagg = engine_args.enable_disagg
+        elif backend_type == BackendType.VLLM:
+            self.enable_engine_pd_disagg = False
+        elif backend_type == BackendType.SIM_VLLM:
+            self.enable_engine_pd_disagg = False
+        else:
+            raise ValueError(f"Unsupported backend type: {backend_type}")
+
+    @classmethod
+    def from_llumnix_config(cls, cfg: LlumnixConfig = get_llumnix_config()) -> 'InstanceArgs':
+        # Get the list of attributes of this dataclass.
+        attrs = [attr.name for attr in dataclasses.fields(cls)]
+        cfg_attrs = [attr for attr in attrs if hasattr(cfg.INSTANCE, attr.upper())]
+        # Set the attributes from the parsed arguments.
+        # The defalut values of attributes are defined in default.py.
+        instance_args = cls(**{attr: getattr(cfg.INSTANCE, attr.upper()) for attr in cfg_attrs})
+        return instance_args
+
+    @classmethod
+    def check_args(cls, args: 'InstanceArgs', manager_args: ManagerArgs,
+                   launch_model: LaunchMode, parser: argparse.ArgumentParser):
+        # pylint: disable=protected-access
+        for action in parser._optionals._actions:
+            if hasattr(action, 'choices') and action.choices is not None and hasattr(args, action.dest):
+                assert getattr(args, action.dest) in action.choices, f"{action.dest} should be one of {action.choices}."
+
+        assert not args.simulator_mode or args.profiling_result_file_path is not None, \
+            "Set profiling_result_file_path args when enable simulator mode"
+
+        # instance_type check
+        if manager_args.enable_pd_disagg and launch_model == LaunchMode.LOCAL:
+            assert args.instance_type in ['prefill', 'decode'], \
+                "instance_type should be prefill or decode if enable_pd_disagg is set."
+
+    def create_migration_config(self) -> MigrationConfig:
+        migration_config = MigrationConfig(self.request_migration_policy,
+                                           self.migration_backend,
+                                           self.migration_buffer_blocks,
+                                           self.migration_num_layers,
+                                           self.migration_last_stage_max_blocks,
+                                           self.migration_max_stages,
+                                           self.migration_backend_init_timeout,
+                                           self.migration_backend_transfer_type,
+                                           self.grpc_migration_backend_server_address,
+                                           self.kvtransfer_migration_backend_naming_url)
+        return migration_config
+
+    @staticmethod
+    def add_cli_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+        parser.add_argument('--instance-type',
+                            type=str,
+                            choices=['prefill', 'decode', 'no_constraints'],
+                            help="instance type for the engine. When non-pd-disaggregation option, set instance_type \
+                                to no_constraints. For pd-disaggregation implemented via LLuminx, specify instance_type \
+                                as either prefill or decode for local launch model and it is not necessary to set for \
+                                global launch model as the manager will automatically determine the instance type and \
+                                quantity based on the --pd-ratio. When pd-disaggregation is handled internally within \
+                                the LLM engine, don't set --enable-pd-disagg. --instance-type parameters should not \
+                                alse be set. Instead, the instance_type will be automatically assigned to either prefill \
+                                or decode based on engine_args for local launch mode, and donot set it for global launch \
+                                model.")
         parser.add_argument('--profiling-result-file-path',
                             type=str,
                             help='profiling result file path when using simulator')
         parser.add_argument('--simulator-mode',
                             action='store_true',
                             help='enable simulator mode')
+        parser.add_argument('--dispatch-load-metric',
+                            type=str,
+                            choices=['remaining_steps', 'usage_ratio'],
+                            help='instance dispatch load metric')
+        parser.add_argument('--migration-load-metric',
+                            type=str,
+                            choices=['remaining_steps', 'usage_ratio'],
+                            help='instance migration load metric')
+        parser.add_argument('--enable-defrag',
+                            type=bool,
+                            help='enable defragmentation through migration based on virtual usage')
+        parser.add_argument('--request-migration-policy',
+                            type=str,
+                            default=None,
+                            choices=['LCR', 'SR', 'LR', 'FCW', 'FCWSR'],
+                            help='The request migration policy.\n\n'
+                            '* "LCR" migrate the running request last come.\n'
+                            '* "SR" migrate the running request shortest.\n'
+                            '* "LR" migrate the running request longest.\n'
+                            '* "FCW" migrate the waiting request first come.\n'
+                            '* "FCWSR" migrate the waiting request first come and running request shortest.\n')
         parser.add_argument('--migration-backend',
                             type=str,
                             choices=['gloo','nccl','rayrpc','grpc','kvtransfer'],
@@ -341,7 +435,7 @@ class ManagerArgs:
                             help='timeout(s) for initializing migration backend')
         parser.add_argument('--migration-backend-transfer-type',
                             type=str,
-                            choices=['cuda_ipc','rdma', ''],
+                            choices=['cuda_ipc','rdma'],
                             help='transfer type for migration backend grpc and kvTransfer')
         parser.add_argument('--grpc-migration-backend-server-address',
                             type=str,
@@ -349,30 +443,10 @@ class ManagerArgs:
         parser.add_argument('--kvtransfer-migration-backend-naming-url',
                             type=str,
                             help='url of naming server for kvtransfer migration backend')
-        parser.add_argument('--max-stages',
+        parser.add_argument('--migration-max-stages',
                             type=int,
-                            help='drop migration if the number of stages > max_stages')
-        parser.add_argument('--last-stage-max-blocks',
+                            help='drop migration if the number of stages > migration_max_stages')
+        parser.add_argument('--migration-last-stage-max-blocks',
                             type=int,
-                            help='if the number pf remain blocks < last_stage_max_blocks, do last stage migration')
-
-        parser.add_argument('--enable-pd-disagg',
-                            action='store_true',
-                            help='enable prefill decoding disaggregation')
-        parser.add_argument('--num-dispatch-instances',
-                            type=int,
-                            help='number of available instances for dispatch')
-
-        parser.add_argument('--enable-port-increment',
-                            action='store_true',
-                            help='enable port increment when desploying multiple servers')
-        parser.add_argument('--enable-port-offset-store',
-                            action='store_true',
-                            help='enable store port offset when desploying multiple servers')
-
+                            help='if the number pf remain blocks < migration_last_stage_max_blocks, do last stage migration')
         return parser
-
-@dataclass
-class LaunchArgs:
-    launch_mode: LaunchMode = None
-    backend_type: BackendType = None

--- a/llumnix/arg_utils.py
+++ b/llumnix/arg_utils.py
@@ -25,6 +25,8 @@ from llumnix.backends.backend_interface import BackendType
 from llumnix.entrypoints.utils import LaunchMode
 
 
+# All the default values of llumnix arguments are set in default.py. So all the arguments here are set to None for default.
+
 class LlumnixArgumentParser(argparse.ArgumentParser):
     def __init__(self, *args, **kwargs):
         self.cur_namespace = "llumnix"

--- a/llumnix/backends/vllm/llm_engine.py
+++ b/llumnix/backends/vllm/llm_engine.py
@@ -157,7 +157,8 @@ class LLMEngineLlumnix(_AsyncLLMEngine):
         instance_info.instance_id = self.instance_id
         instance_info.step_id = next(self.step_counter)
         instance_info.timestamp = time.time()
-        instance_info.profiling_data=(instance_info.inference_type.value,
+        # TODO(KuilongCui): add cli_args to determine whether to collect profiling data
+        instance_info.profiling_data=(instance_info.inference_type.value if instance_info.inference_type else "",
                                       instance_info.num_seqs,
                                       sum(instance_info.running_seq_lens),
                                       self.model_executor.last_inference_latency)

--- a/llumnix/backends/vllm/utils.py
+++ b/llumnix/backends/vllm/utils.py
@@ -24,7 +24,7 @@ from vllm.model_executor.layers.sampler import SamplingMetadata, SamplingTensors
                                                 VLLM_INVALID_TOKEN_ID, _multinomial, _modify_greedy_probs_inplace, get_pythonized_sample_results
 
 from llumnix.logging.logger import init_logger
-from llumnix.arg_utils import ManagerArgs
+from llumnix.arg_utils import InstanceArgs
 
 logger = init_logger(__name__)
 
@@ -46,15 +46,14 @@ def detect_unsupported_feature(engine_args: EngineArgs) -> None:
     if unsupported_feature:
         raise ValueError(f'Unsupported feature: Llumnix does not support "{unsupported_feature}" currently.')
 
-def check_engine_args(engine_args: AsyncEngineArgs, manager_args: ManagerArgs) -> None:
-    assert engine_args.worker_use_ray, \
-            ("In Llumnix, engine and worker must be ray actor.")
-    migration_config = manager_args.create_migration_config()
+def check_engine_args(engine_args: AsyncEngineArgs, intance_args: InstanceArgs) -> None:
+    assert engine_args.worker_use_ray, "In Llumnix, engine and worker must be ray actor."
+    migration_config = intance_args.create_migration_config()
     engine_config = engine_args.create_engine_config()
     parallel_config = engine_config.parallel_config
     if parallel_config.world_size > 1 and migration_config.migration_backend == 'nccl':
         logger.warning("Llumnix does not support TP or PP when the migration backend is nccl, change migration backend to gloo.")
-        manager_args.migration_backend = 'gloo'
+        intance_args.migration_backend = 'gloo'
     detect_unsupported_feature(engine_args)
 
 def _get_dtype_size(dtype: torch.dtype) -> int:

--- a/llumnix/backends/vllm/worker.py
+++ b/llumnix/backends/vllm/worker.py
@@ -141,9 +141,5 @@ class MigrationWorker(Worker):
 
     def shutdown(self) -> None:
         torch.cuda.synchronize()
-        del self.model_runner
-        del self.cache_engine
-        del self.gpu_cache
-        del self.migration_backend
         torch.cuda.empty_cache()
         torch.cuda.reset_max_memory_allocated()

--- a/llumnix/config/default.py
+++ b/llumnix/config/default.py
@@ -11,8 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
-
 from .config import LlumnixConfig as LC
 
 # -----------------------------------------------------------------------------
@@ -47,9 +45,7 @@ _C.SERVER.CONFIG_FILE = None
 # Disable keep serve process alive
 _C.SERVER.DISABLE_KEEP_SERVE_PROCESS_ALIVE = False
 
-# -----------------------------------------------------------------------------
-# RAY CONFIGURATION
-# -----------------------------------------------------------------------------
+# ----------------------------- RAY CONFIGURATION -----------------------------
 # If True, launch Ray cluster in API server
 _C.SERVER.LAUNCH_RAY_CLUSTER = False
 # Port number for the Ray cluster
@@ -71,63 +67,34 @@ _C.MANAGER.DISABLE_LOG_REQUESTS_MANAGER = False
 _C.MANAGER.LOG_INSTANCE_INFO = False
 # Log filename
 _C.MANAGER.LOG_FILENAME = "server.log"
-# Enable simulator mode
-_C.MANAGER.SIMULATOR_MODE = False
-# Profiling result file path when using simulator
-_C.MANAGER.PROFILING_RESULT_FILE_PATH = None
 # Enable port increment when deploying multiple servers
 _C.MANAGER.ENABLE_PORT_INCREMENT = False
 # Enable store port offset when deploying multiple servers
 _C.MANAGER.ENABLE_PORT_OFFSET_STORE = False
+# Enable prefill decoding disaggregation
+_C.MANAGER.ENABLE_PD_DISAGG = False
+# The p:d ratio used in gloabl launch model
+_C.MANAGER.PD_RATIO = "1:1"
 
-# -----------------------------------------------------------------------------
-# DISPATCH CONFIGURATION
-# -----------------------------------------------------------------------------
-# Instance load metric
-_C.MANAGER.LOAD_METRIC = 'remaining_steps'
+# -------------------------- DISPATCH CONFIGURATION ---------------------------
 # Request dispatch policy
 _C.MANAGER.DISPATCH_POLICY = 'load'
 
-# -----------------------------------------------------------------------------
-# MIGRATION CONFIGURATION
-# -----------------------------------------------------------------------------
+# -------------------------- MIGRATION CONFIGURATION --------------------------
 # Enable migrate requests between instances
 _C.MANAGER.ENABLE_MIGRATION = False
-# Enable defragmentation through migration based on virtual usage
-_C.MANAGER.ENABLE_DEFRAG = False
 # Pair migration frequency
 _C.MANAGER.PAIR_MIGRATION_FREQUENCY = 1
 # Pair migration policy
 _C.MANAGER.PAIR_MIGRATION_POLICY = 'defrag_constrained'
 # Migrate out instance load threshold
-_C.MANAGER.MIGRATE_OUT_THRESHOLD = 3.0
-# Request migration policy
-_C.MANAGER.REQUEST_MIGRATION_POLICY = 'SR'
-# Drop migration if the number of stages > max_stages
-_C.MANAGER.MAX_STAGES = 3
-# If the number of remain blocks < last_stage_max_blocks, do last stage migration
-_C.MANAGER.LAST_STAGE_MAX_BLOCKS = 16
+_C.MANAGER.MIGRATE_OUT_THRESHOLD = -3.0
 
-# Communication backend of migration
-_C.MANAGER.MIGRATION_BACKEND = "gloo"
-# Number of cache blocks in migration
-_C.MANAGER.MIGRATION_BUFFER_BLOCKS = 512
-# Number of kv-cache layers to transfer in each round during migration
-_C.MANAGER.MIGRATION_NUM_LAYERS = 1
-# Timeout(s) for initializing migration backend
-_C.MANAGER.MIGRATION_BACKEND_INIT_TIMEOUT = 10.0
-# Transfer type for migration backend kvTransfer
-_C.MANAGER.MIGRATION_BACKEND_TRANSFER_TYPE = "rdma"
-# Address of grpc server for migration backend
-_C.MANAGER.GRPC_MIGRATION_BACKEND_SERVER_ADDRESS = "127.0.0.1:50051"
-# URL of naming server for kvtransfer migration backend
-_C.MANAGER.KVTRANSFER_MIGRATION_BACKEND_NAMING_URL = "file:/tmp/llumnix/naming/"
-
-# -----------------------------------------------------------------------------
-# SCALING CONFIGURATION
-# -----------------------------------------------------------------------------
+# --------------------------- SCALING CONFIGURATION ---------------------------
 # Enable auto scaling
 _C.MANAGER.ENABLE_SCALING = False
+# Instance scaling load metric
+_C.MANAGER.SCALING_LOAD_METRIC = 'remaining_steps'
 # Minimum number of instances
 _C.MANAGER.MIN_INSTANCES = 1
 # Maximum number of instances
@@ -137,14 +104,47 @@ _C.MANAGER.SCALING_INTERVAL = 10
 # Scaling policy
 _C.MANAGER.SCALING_POLICY = 'avg_load'
 # Scale up threshold
-_C.MANAGER.SCALE_UP_THRESHOLD = 10
+_C.MANAGER.SCALE_UP_THRESHOLD = -10
 # Scale down threshold
-_C.MANAGER.SCALE_DOWN_THRESHOLD = 60
+_C.MANAGER.SCALE_DOWN_THRESHOLD = -60
 
 # -----------------------------------------------------------------------------
-# PREFILL DECODING DISAGGREGATION CONFIGURATION
+# INSTANCE CONFIGURATION
 # -----------------------------------------------------------------------------
-# Enable prefill decoding disaggregation
-_C.MANAGER.ENABLE_PD_DISAGG = False
-# Number of available instances for dispatch. math.inf indicates that all instances can be used for dispatching
-_C.MANAGER.NUM_DISPATCH_INSTANCES = math.inf
+_C.INSTANCE = LC()
+# Engine types: prefill, decode, no_constraints
+_C.INSTANCE.INSTANCE_TYPE = "no_constraints"
+# Enable simulator mode
+_C.INSTANCE.SIMULATOR_MODE = False
+# Profiling result file path when using simulator
+_C.INSTANCE.PROFILING_RESULT_FILE_PATH = None
+
+# ------------------------- LOAD METRICS CONFIGURATION ------------------------
+# Instance dispatch load metric
+_C.INSTANCE.DISPATCH_LOAD_METRIC = 'remaining_steps'
+# Instance migration load metric
+_C.INSTANCE.MIGRATION_LOAD_METRIC = 'remaining_steps'
+
+# -------------------------- MIGRATION CONFIGURATION --------------------------
+# Enable defragmentation through migration based on virtual usage
+_C.INSTANCE.ENABLE_DEFRAG = False
+# Request migration policy
+_C.INSTANCE.REQUEST_MIGRATION_POLICY = 'SR'
+# Drop migration if the number of stages > migration_max_stages
+_C.INSTANCE.MIGRATION_MAX_STAGES = 3
+# If the number of remain blocks < migration_last_stage_max_blocks, do last stage migration
+_C.INSTANCE.MIGRATION_LAST_STAGE_MAX_BLOCKS = 16
+# Communication backend of migration
+_C.INSTANCE.MIGRATION_BACKEND = "gloo"
+# Number of cache blocks in migration
+_C.INSTANCE.MIGRATION_BUFFER_BLOCKS = 512
+# Number of kv-cache layers to transfer in each round during migration
+_C.INSTANCE.MIGRATION_NUM_LAYERS = 1
+# Timeout(s) for initializing migration backend
+_C.INSTANCE.MIGRATION_BACKEND_INIT_TIMEOUT = 10.0
+# Transfer type for migration backend kvTransfer
+_C.INSTANCE.MIGRATION_BACKEND_TRANSFER_TYPE = "rdma"
+# Address of grpc server for migration backend
+_C.INSTANCE.GRPC_MIGRATION_BACKEND_SERVER_ADDRESS = "127.0.0.1:50051"
+# URL of naming server for kvtransfer migration backend
+_C.INSTANCE.KVTRANSFER_MIGRATION_BACKEND_NAMING_URL = "file:/tmp/llumnix/naming/"

--- a/llumnix/constants.py
+++ b/llumnix/constants.py
@@ -21,6 +21,9 @@ CHECK_DEPLOYMENT_STATES_INTERVAL: float = 30.0
 WATCH_DEPLOYMENT_INTERVAL: float = 10.0
 WATCH_DEPLOYMENT_INTERVAL_PENDING_INSTANCE: float = 120.0
 
+# llumnix/global_scheduler/dispatch_scheduler.py
+DISPATCH_LOG_FREQUENCY = 100
+
 # llumnix/entrypoints/setup.py
 MAX_RAY_RESTARTS: int = 10
 RAY_RESTART_INTERVAL: float = 10.0

--- a/llumnix/entrypoints/setup.py
+++ b/llumnix/entrypoints/setup.py
@@ -22,7 +22,7 @@ from llumnix.manager import Manager
 from llumnix.llumlet.llumlet import Llumlet
 from llumnix.logging.logger import init_logger
 from llumnix.utils import random_uuid, get_manager_name
-from llumnix.arg_utils import ManagerArgs, EntrypointsArgs, LaunchArgs
+from llumnix.arg_utils import ManagerArgs, EntrypointsArgs, LaunchArgs, InstanceArgs
 from llumnix.queue.queue_type import QueueType
 from llumnix.server_info import ServerInfo
 from llumnix.queue.utils import init_request_output_queue_server
@@ -92,33 +92,41 @@ def setup_ray_cluster(entrypoints_args) -> None:
                            log_to_driver=not entrypoints_args.disable_log_to_driver)
 
 def init_manager(manager_args: ManagerArgs,
+                 instance_args: InstanceArgs = None,
                  entrypoints_args: EntrypointsArgs = None,
                  engine_args = None,
                  launch_args: LaunchArgs = None,
                  ) -> Manager:
     # Only one instance create the manager actor, the other instances get the existing manager actor through ray.
     try:
-        manager = Manager.from_args(manager_args=manager_args,
-                                    entrypoints_args=entrypoints_args,
-                                    engine_args=engine_args,
-                                    launch_args=launch_args)
+        manager = Manager.from_args(
+            entrypoints_args=entrypoints_args,
+            manager_args=manager_args,
+            instance_args=instance_args,
+            engine_args=engine_args,
+            launch_args=launch_args)
         logger.info("Init Manager on current node.")
     except ValueError:
         manager = ray.get_actor(get_manager_name(), namespace='llumnix')
         logger.info("Get existing Manager.")
     return manager
 
-def init_llumnix_components(manager_args: ManagerArgs,
+def init_llumnix_components(entrypoints_args: EntrypointsArgs,
+                            manager_args: ManagerArgs,
+                            instance_args: InstanceArgs,
                             engine_args,
-                            request_output_queue_type: QueueType,
-                            request_output_queue_port: str,
-                            backend_type: BackendType) -> Tuple[Manager, List[str], List[Llumlet], QueueServerBase]:
+                            launch_args: LaunchArgs,
+                            ) -> Tuple[Manager, List[str], List[Llumlet], QueueServerBase]:
     manager = init_manager(manager_args)
 
+    backend_type: BackendType = launch_args.backend_type
+    request_output_queue_type: QueueType = QueueType(entrypoints_args.request_output_queue_type)
     instance_ids, instances = retry_manager_method_sync(
-        manager.init_instances.remote, 'init_instances', request_output_queue_type, backend_type, engine_args)
+        manager.init_instances.remote, 'init_instances', request_output_queue_type,
+        backend_type, instance_args, engine_args)
 
     ip = get_ip_address()
+    request_output_queue_port: str = entrypoints_args.request_output_queue_port
     request_output_queue = init_request_output_queue_server(ip, request_output_queue_port, request_output_queue_type)
 
     return manager, instance_ids, instances, request_output_queue
@@ -138,32 +146,25 @@ def setup_entrypoints_context(entrypoints_args, manager, instance_ids, instances
 
     log_requests = not entrypoints_args.disable_log_requests_server
     log_request_timestamps = entrypoints_args.log_request_timestamps
-    logger.info("log_requests: {}, log_request_timestamps: {}".format(log_requests, log_request_timestamps))
-
     entrypoints_context = EntrypointsContext(manager,
                                              instances_dict,
                                              request_output_queue,
                                              server_info,
                                              log_requests,
                                              log_request_timestamps)
-
     return entrypoints_context
 
-def _setup_llumnix_local(manager_args, entrypoints_args, engine_args, launch_args) -> EntrypointsContext:
+def _setup_llumnix_local(entrypoints_args, manager_args, instance_args, engine_args, launch_args) -> EntrypointsContext:
     manager, instance_ids, instances, request_output_queue = \
-        init_llumnix_components(manager_args,
-                                engine_args,
-                                QueueType(entrypoints_args.request_output_queue_type),
-                                entrypoints_args.request_output_queue_port,
-                                launch_args.backend_type)
+        init_llumnix_components(entrypoints_args, manager_args, instance_args, engine_args, launch_args)
 
     return setup_entrypoints_context(entrypoints_args, manager, instance_ids, instances, request_output_queue)
 
-def _setup_llumnix_global(manager_args, entrypoints_args, engine_args, launch_args) -> None:
-    _ = init_manager(manager_args, entrypoints_args, engine_args, launch_args)
+def _setup_llumnix_global(entrypoints_args, manager_args, instance_args, engine_args, launch_args) -> None:
+    _ = init_manager(manager_args, instance_args, entrypoints_args, engine_args, launch_args)
 
-def setup_llumnix(manager_args, entrypoints_args, engine_args, launch_args) -> Optional[EntrypointsContext]:
+def setup_llumnix(entrypoints_args, manager_args, instance_args, engine_args, launch_args) -> Optional[EntrypointsContext]:
     if launch_args.launch_mode == LaunchMode.LOCAL:
-        return _setup_llumnix_local(manager_args, entrypoints_args, engine_args, launch_args)
+        return _setup_llumnix_local(entrypoints_args, manager_args, instance_args, engine_args, launch_args)
 
-    return _setup_llumnix_global(manager_args, entrypoints_args, engine_args, launch_args)
+    return _setup_llumnix_global(entrypoints_args, manager_args, instance_args, engine_args, launch_args)

--- a/llumnix/entrypoints/vllm/api_server.py
+++ b/llumnix/entrypoints/vllm/api_server.py
@@ -179,9 +179,9 @@ if __name__ == "__main__":
 
     cli_args = add_cli_args(parser)
     cfg = get_llumnix_config(cli_args.config_file, cli_args)
-    entrypoints_args, manager_args, engine_args = get_args(cfg, parser, cli_args)
 
-    backend_type = BackendType.VLLM if not manager_args.simulator_mode else BackendType.SIM_VLLM
+    entrypoints_args, manager_args, instance_args, engine_args = get_args(cfg, LaunchMode.LOCAL, parser, cli_args)
+    backend_type = BackendType.VLLM if not instance_args.simulator_mode else BackendType.SIM_VLLM
     launch_args = LaunchArgs(launch_mode=LaunchMode.LOCAL, backend_type=backend_type)
 
     # Launch or connect to the ray cluster for multi-node serving.
@@ -189,7 +189,7 @@ if __name__ == "__main__":
 
     # if gpu is not available, it means that this node is head pod without any llumnix components
     if is_gpu_available():
-        entrypoints_context = setup_llumnix(manager_args, entrypoints_args, engine_args, launch_args)
+        entrypoints_context = setup_llumnix(entrypoints_args, manager_args, instance_args, engine_args, launch_args)
         llumnix_client = LlumnixClientVLLM(entrypoints_context)
 
         # Start the api server after all the components of llumnix are ready.

--- a/llumnix/entrypoints/vllm/arg_utils.py
+++ b/llumnix/entrypoints/vllm/arg_utils.py
@@ -1,31 +1,39 @@
 from vllm.engine.arg_utils import AsyncEngineArgs
-from llumnix.backends.vllm.utils import check_engine_args
 
-from llumnix.arg_utils import EntrypointsArgs, ManagerArgs
 from llumnix.logging.logger import init_logger
+from llumnix.backends.backend_interface import BackendType
+from llumnix.backends.vllm.utils import check_engine_args
+from llumnix.arg_utils import EntrypointsArgs, ManagerArgs, InstanceArgs, LlumnixArgumentParser
 
 logger = init_logger(__name__)
 
 
-def add_cli_args(parser):
+def add_cli_args(parser: LlumnixArgumentParser):
     parser.set_namespace("llumnix")
     parser = EntrypointsArgs.add_cli_args(parser)
     parser = ManagerArgs.add_cli_args(parser)
+    parser = InstanceArgs.add_cli_args(parser)
     parser.set_namespace("vllm")
     parser = AsyncEngineArgs.add_cli_args(parser)
     cli_args = parser.parse_args()
     return cli_args
 
-def get_args(cfg, parser, cli_args):
-    entrypoints_args = EntrypointsArgs.from_llumnix_config(cfg)
-    EntrypointsArgs.check_args(entrypoints_args, parser)
-    manager_args = ManagerArgs.from_llumnix_config(cfg)
-    ManagerArgs.check_args(manager_args, parser)
+def get_args(cfg, launch_model, parser, cli_args):
     engine_args = AsyncEngineArgs.from_cli_args(cli_args)
-    check_engine_args(engine_args, manager_args)
+    instance_args: InstanceArgs = InstanceArgs.from_llumnix_config(cfg)
+    instance_args.init_from_engine_args(engine_args, BackendType.VLLM)
+    manager_args = ManagerArgs.from_llumnix_config(cfg)
+    manager_args.init_from_instance_args(instance_args)
+    entrypoints_args = EntrypointsArgs.from_llumnix_config(cfg)
+
+    EntrypointsArgs.check_args(entrypoints_args, parser)
+    ManagerArgs.check_args(manager_args, parser)
+    InstanceArgs.check_args(instance_args, manager_args, launch_model, parser)
+    check_engine_args(engine_args, instance_args)
 
     logger.info("entrypoints_args: {}".format(entrypoints_args))
     logger.info("manager_args: {}".format(manager_args))
+    logger.info("instance_args: {}".format(instance_args))
     logger.info("engine_args: {}".format(engine_args))
 
-    return entrypoints_args, manager_args, engine_args
+    return entrypoints_args, manager_args, instance_args, engine_args

--- a/llumnix/entrypoints/vllm/client.py
+++ b/llumnix/entrypoints/vllm/client.py
@@ -1,6 +1,7 @@
 import copy
 import time
 import asyncio
+from typing import Dict
 from functools import partial
 
 import ray

--- a/llumnix/entrypoints/vllm/serve.py
+++ b/llumnix/entrypoints/vllm/serve.py
@@ -23,9 +23,9 @@ if __name__ == "__main__":
 
     cli_args = add_cli_args(parser)
     cfg = get_llumnix_config(cli_args.config_file, cli_args)
-    entrypoints_args, manager_args, engine_args = get_args(cfg, parser, cli_args)
+    entrypoints_args, manager_args, instance_args, engine_args = get_args(cfg, LaunchMode.GLOBAL, parser, cli_args)
 
-    backend_type = BackendType.VLLM if not manager_args.simulator_mode else BackendType.SIM_VLLM
+    backend_type = BackendType.VLLM if not instance_args.simulator_mode else BackendType.SIM_VLLM
     launch_args = LaunchArgs(launch_mode=LaunchMode.GLOBAL, backend_type=BackendType.VLLM)
 
     # Assume that there is an existing ray cluster when using centralized deployment.
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     request_output_queue = RayQueue(actor_options={"namespace": "llumnix",
                                                    "name": "magic_ray_queue"})
 
-    setup_llumnix(manager_args, entrypoints_args, engine_args, launch_args)
+    setup_llumnix(entrypoints_args, manager_args, instance_args, engine_args, launch_args)
 
     # keep the process alive to get the terminal output.
     if not entrypoints_args.disable_keep_serve_process_alive:

--- a/llumnix/global_scheduler/dispatch_scheduler.py
+++ b/llumnix/global_scheduler/dispatch_scheduler.py
@@ -16,107 +16,68 @@ from abc import ABC, abstractmethod
 import random
 
 from llumnix.logging.logger import init_logger
-from llumnix.instance_info import InstanceLoadCalculator, InstanceInfo
+from llumnix.instance_info import InstanceInfo, InstanceType
+from llumnix.arg_utils import InstanceArgs
+from llumnix.constants import DISPATCH_LOG_FREQUENCY
 
 logger = init_logger(__name__)
 
 
 class DispatchScheduler:
-    def __init__(self,
-                 dispatch_policy: str,
-                 instance_load_calculator: InstanceLoadCalculator,
-                 num_dispatch_instances: int) -> None:
+    def __init__(self, dispatch_policy: str,) -> None:
         self.dispatch_policy = DispatchPolicyFactory.get_policy(dispatch_policy)
-        self.instance_load_calculator = instance_load_calculator
-        self.num_instances = 0
-        self.instance_id_set: Set[str] = set()
         self.available_dispatch_instance_set: Set[str] = set()
-        self.num_dispatch_instances = num_dispatch_instances
-        # instance info args
         self.instance_info: Dict[str, InstanceInfo] = {}
-        self.sorted_instance_infos: List[InstanceInfo] = None
         # statistics
-        self.num_requests = 0
+        self.total_num_requests = 0
         self.instance_num_requests: Dict[str, int] = {}
 
     def dispatch(self) -> str:
-        self.num_requests += 1
-        if isinstance(self.dispatch_policy, (Load, Queue)):
-            self._sort_instance_infos(descending=False)
+        self.total_num_requests += 1
         dispatch_instance_id = self.dispatch_policy.dispatch(self.instance_num_requests,
-                                                             self.sorted_instance_infos)
+                                                             self.instance_info.values())
         self.instance_num_requests[dispatch_instance_id] += 1
-        if self.num_requests % 100 == 0:
-            logger.info("num_requests: {}".format(self.num_requests))
+        if self.total_num_requests % DISPATCH_LOG_FREQUENCY == 0:
+            logger.info("dispatch scheduler total_dispatched_requests: {}".format(self.total_num_requests))
             for instance_id, num_requests in self.instance_num_requests.items():
                 logger.info("instance {} num_dispatched_requests: {}".format(instance_id, num_requests))
         return dispatch_instance_id
 
-    def update_instance_infos(self,
-                              instance_info: Dict[str, InstanceInfo]) -> None:
-        self.instance_info = instance_info
+    def update_instance_infos(self, instance_infos: Dict[str, InstanceInfo]) -> None:
+        for instance_id, instance_info in instance_infos.items():
+            if instance_id not in self.available_dispatch_instance_set:
+                continue
+            self.instance_info[instance_id] = instance_info
 
-    def add_instance(self, instance_id: str) -> None:
-        self.instance_id_set.add(instance_id)
-        self.num_instances = len(self.instance_id_set)
-
-        # TODO(KuilongCui): a hacky method is being used to avoid the only-decode type engine dispatched
-        if "decode" not in instance_id:
-            if self.num_dispatch_instances <= 0 or (self.num_dispatch_instances > 0 and
-                len(self.available_dispatch_instance_set) < self.num_dispatch_instances):
-                self.available_dispatch_instance_set.add(instance_id)
-                self.instance_num_requests[instance_id] = 0
+    def add_instance(self, instance_id: str, instance_args: InstanceArgs) -> None:
+        if instance_args.instance_type in [InstanceType.NO_CONSTRAINTS, InstanceType.PREFILL]:
+            self.available_dispatch_instance_set.add(instance_id)
+            self.instance_num_requests[instance_id] = 0
 
     def remove_instance(self, instance_id: str) -> None:
-        self.instance_id_set.remove(instance_id)
-        self.num_instances = len(self.instance_id_set)
-        if instance_id in self.instance_num_requests:
-            del self.instance_num_requests[instance_id]
-        else:
-            logger.warning("instance {} not in instance_num_requests".format(instance_id))
         if instance_id in self.available_dispatch_instance_set:
             self.available_dispatch_instance_set.remove(instance_id)
-            # TODO(KuilongCui): Check it when there is no decode instance.
-            if self.num_instances >= self.num_dispatch_instances:
-                free_instance_id = next(iter(self.instance_id_set - self.available_dispatch_instance_set))
-                self.available_dispatch_instance_set.add(free_instance_id)
-
-    def _sort_instance_infos(self,
-                            descending: bool = True) -> None:
-        instance_infos: List[InstanceInfo] = list(self.instance_info.values())
-        available_instance_infos = [info for info in instance_infos if info.instance_id in self.available_dispatch_instance_set]
-        if isinstance(self.dispatch_policy, Queue):
-            key_attr = 'num_waiting_requests'
-        else:
-            key_attr = 'instance_load_dispatch_scale'
-        self.sorted_instance_infos = sorted(
-            available_instance_infos,
-            key=lambda instance_info: getattr(instance_info, key_attr),
-            reverse=descending
-        )
+            self.instance_num_requests.pop(instance_id, None)
 
 class DispatchPolicy(ABC):
-    def __init__(self):
-        self.instance_ptr = 0
-
     @abstractmethod
     def dispatch(self,
                  instance_num_requests: Dict[str, int],
-                 sorted_instance_infos: List[InstanceInfo]) -> int:
+                 available_instance_infos: List[InstanceInfo]) -> str:
         pass
 
 # Dispatch all requests to a single instance, used only for testing
 class Flood(DispatchPolicy):
     def dispatch(self,
                  instance_num_requests: Dict[str, int],
-                 sorted_instance_infos: List[InstanceInfo]) -> str:
+                 available_instance_infos: List[InstanceInfo]) -> str:
         instance_id = max(instance_num_requests, key=instance_num_requests.get)
         return instance_id
 
 class Balanced(DispatchPolicy):
     def dispatch(self,
                  instance_num_requests: Dict[str, int],
-                 sorted_instance_infos: List[InstanceInfo]) -> str:
+                 available_instance_infos: List[InstanceInfo]) -> str:
         # dispatch request according to the number of requests dispatched to instance by manager
         instance_id = min(instance_num_requests, key=instance_num_requests.get)
         return instance_id
@@ -124,35 +85,42 @@ class Balanced(DispatchPolicy):
 class Load(DispatchPolicy):
     def dispatch(self,
                  instance_num_requests: Dict[str, int],
-                 sorted_instance_infos: List[InstanceInfo]) -> str:
+                 available_instance_infos: List[InstanceInfo]) -> str:
+        sorted_instance_infos = sorted(
+            available_instance_infos,
+            key=lambda instance_info: getattr(instance_info, 'dispatch_load_metric'),
+        )
         instance_id = sorted_instance_infos[0].instance_id
-        logger.info("dispatch to {}, load: {}".format(instance_id, sorted_instance_infos[0].instance_load_dispatch_scale))
+        logger.debug("dispatch to {}, load: {}".format(instance_id, sorted_instance_infos[0].dispatch_load_metric))
         return instance_id
 
 class Queue(DispatchPolicy):
     def dispatch(self,
                  instance_num_requests: Dict[str, int],
-                 sorted_instance_infos: List[InstanceInfo]) -> str:
+                 available_instance_infos: List[InstanceInfo]) -> str:
+        sorted_instance_infos = sorted(
+            available_instance_infos,
+            key=lambda instance_info: getattr(instance_info, 'num_waiting_requests'),
+        )
         min_queue_size = sorted_instance_infos[0].num_waiting_requests
         instance_id_list = []
         for instance_info in sorted_instance_infos:
             if instance_info.num_waiting_requests == min_queue_size:
                 instance_id_list.append(instance_info.instance_id)
         instance_id = random.choice(instance_id_list)
-        logger.info("dispatch to {}, queue size: {}".format(instance_id, sorted_instance_infos[0].num_waiting_requests))
+        logger.debug("dispatch to {}, queue size: {}".format(instance_id, sorted_instance_infos[0].num_waiting_requests))
         return instance_id
 
 class RoundRobin(DispatchPolicy):
-    prev_instance_idx: int = -1
+    next_instance_idx: int = 0
 
     def dispatch(self,
                  instance_num_requests: Dict[str, int],
-                 sorted_instance_infos: List[InstanceInfo]) -> str:
+                 available_instance_infos: List[InstanceInfo]) -> str:
         all_instance_ids = sorted(instance_num_requests.keys())
-        cur_instance_idx = (self.prev_instance_idx + 1) % len(all_instance_ids)
-
-        target_instance_id = all_instance_ids[cur_instance_idx]
-        self.prev_instance_idx = cur_instance_idx
+        assert len(all_instance_ids) > 0
+        target_instance_id = all_instance_ids[self.next_instance_idx % len(all_instance_ids)]
+        self.next_instance_idx += 1
         return target_instance_id
 
 class DispatchPolicyFactory:

--- a/llumnix/global_scheduler/global_scheduler.py
+++ b/llumnix/global_scheduler/global_scheduler.py
@@ -16,60 +16,45 @@ import math
 
 from llumnix.logging.logger import init_logger
 from llumnix.internal_config import GlobalSchedulerConfig
-from llumnix.instance_info import InstanceLoadCalculator, InstanceInfo
+from llumnix.instance_info import InstanceInfo
 from llumnix.global_scheduler.dispatch_scheduler import DispatchScheduler
 from llumnix.global_scheduler.migration_scheduler import MigrationScheduler
 from llumnix.global_scheduler.migration_policy import PairMigrationConstraints
 from llumnix.global_scheduler.scaling_scheduler import ScalingScheduler
+from llumnix.arg_utils import InstanceArgs
 
 logger = init_logger(__name__)
 
 
 class GlobalScheduler:
-    def __init__(self,
-                 global_scheduler_config: GlobalSchedulerConfig) -> None:
+    def __init__(self, global_scheduler_config: GlobalSchedulerConfig) -> None:
         self.global_scheduler_config = global_scheduler_config
-        # instance load and instance info args
-        self.load_metric = global_scheduler_config.load_metric
-        self.enable_defrag = global_scheduler_config.enable_defrag
-        self.enable_pd_disagg = global_scheduler_config.enable_pd_disagg
-        self.instance_load_calculator = InstanceLoadCalculator(load_metric=self.load_metric,
-                                                               enable_defrag=self.enable_defrag)
-        # dispatch args
-        self.dispatch_policy = global_scheduler_config.dispatch_policy
-        self.dispatch_scheduler = DispatchScheduler(global_scheduler_config.dispatch_policy,
-                                                    self.instance_load_calculator,
-                                                    global_scheduler_config.num_dispatch_instances)
-        # migrate args
-        self.migration_scheduler = MigrationScheduler(global_scheduler_config.pair_migration_policy,
-                                                      global_scheduler_config.migrate_out_load_threshold,
-                                                      self.instance_load_calculator,
-                                                      global_scheduler_config.migration_backend)
-        # auto-scaling args
-        self.scaling_scheduler = ScalingScheduler(global_scheduler_config.scale_up_threshold,
-                                                  global_scheduler_config.scale_down_threshold,
-                                                  global_scheduler_config.scaling_policy,
-                                                  self.instance_load_calculator,
-                                                  self.enable_pd_disagg,
-                                                  global_scheduler_config.num_dispatch_instances)
-
         self.num_instances = 0
         self.instance_id_set: Set[str] = set()
         self.instance_info: Dict[str, InstanceInfo] = {}
 
+        # dispatch args
+        self.dispatch_scheduler = DispatchScheduler(global_scheduler_config.dispatch_policy)
+        # migrate args
+        self.migration_scheduler = MigrationScheduler(global_scheduler_config.pair_migration_policy,
+                                                      global_scheduler_config.migrate_out_load_threshold,
+                                                      global_scheduler_config.is_group_kind_migration_backend)
+        # auto-scaling args
+        self.scaling_scheduler = ScalingScheduler(global_scheduler_config.scale_up_threshold,
+                                                  global_scheduler_config.scale_down_threshold,
+                                                  global_scheduler_config.scaling_policy,
+                                                  global_scheduler_config.scaling_load_metric,
+                                                  global_scheduler_config.enable_pd_disagg,)
+
     def update_instance_infos(self, instance_infos: List[InstanceInfo]) -> None:
         for instance_info in instance_infos:
             if instance_info.instance_id in self.instance_id_set:
-                # Llumnix have different instance load compuatation methods for dispatch/migrate/scale.
-                instance_info.instance_load_dispatch_scale = self.instance_load_calculator.compute_instance_load(instance_info, action='dispatch')
-                instance_info.instance_load_migrate = self.instance_load_calculator.compute_instance_load(instance_info, action='migrate')
-                instance_info.instance_type = self.scaling_scheduler.get_instance_type_info(instance_info.instance_id)
                 self.instance_info[instance_info.instance_id] = instance_info
 
     def dispatch(self) -> str:
         self.dispatch_scheduler.update_instance_infos(self.instance_info)
         instance_id = self.dispatch_scheduler.dispatch()
-        request_expected_steps = 1 if self.enable_pd_disagg else math.inf
+        request_expected_steps = 1 if self.global_scheduler_config.enable_pd_disagg else math.inf
         return instance_id, request_expected_steps
 
     def pair_migration(self, pair_migration_type: PairMigrationConstraints) -> List[Tuple[str, str]]:
@@ -82,17 +67,17 @@ class GlobalScheduler:
         scale_up_num, scale_down_num = self.scaling_scheduler.check_scale()
         return scale_up_num, scale_down_num
 
-    def scale_up(self, instance_id: Union[str, Iterable[str]]) -> int:
+    def scale_up(self, instance_id: Union[str, Iterable[str]], instance_args: List[InstanceArgs]) -> int:
         if isinstance(instance_id, str):
             instance_id = [instance_id,]
         instance_ids = list(instance_id)
-        for ins_id in instance_ids:
+        for ins_id, ins_args in zip(instance_ids, instance_args):
             if ins_id not in self.instance_id_set:
                 logger.info("Scale up instance: {}.".format(ins_id))
                 new_intance_info = self._get_empty_instance_info()
                 new_intance_info.instance_id = ins_id
                 self.instance_info[ins_id] = new_intance_info
-                self._add_instance(ins_id)
+                self._add_instance(ins_id, ins_args)
         logger.info("num_instances: {}, instances: {}".format(self.num_instances, self.instance_id_set))
         return self.num_instances
 
@@ -111,12 +96,12 @@ class GlobalScheduler:
         logger.info("num_instances: {}, instances: {}".format(self.num_instances, self.instance_id_set))
         return self.num_instances
 
-    def _add_instance(self, instance_id: str) -> None:
+    def _add_instance(self, instance_id: str, instance_args: InstanceArgs) -> None:
         self.instance_id_set.add(instance_id)
         self.num_instances = len(self.instance_id_set)
         for scheduler in (self.dispatch_scheduler, self.migration_scheduler, self.scaling_scheduler):
             scheduler.update_instance_infos(self.instance_info)
-            scheduler.add_instance(instance_id)
+            scheduler.add_instance(instance_id, instance_args)
 
     def _remove_instance(self, instance_id: str) -> None:
         self.instance_id_set.remove(instance_id)

--- a/llumnix/global_scheduler/migration_filter.py
+++ b/llumnix/global_scheduler/migration_filter.py
@@ -16,7 +16,7 @@ from abc import ABC, abstractmethod
 
 from llumnix.logging.logger import init_logger
 from llumnix.instance_info import InstanceInfo
-from llumnix.global_scheduler.scaling_scheduler import InstanceType
+from llumnix.instance_info import InstanceType
 from llumnix.global_scheduler.migration_policy import PairMigrationConstraints
 
 logger = init_logger(__name__)
@@ -80,12 +80,12 @@ class LoadConstrainedFilter(MigrationFilterPolicy):
     def filter_src_condition(self, filter_config: MigrationFilterConfig,
                              pair_migration_type: PairMigrationConstraints) -> Callable[[InstanceInfo], bool]:
         return lambda instance_info: instance_info.num_killed_requests > 0 \
-            or instance_info.instance_load_migrate > filter_config.migrate_out_load_threshold
+            or instance_info.migration_load_metric > filter_config.migrate_out_load_threshold
 
     def filter_dst_condition(self, filter_config: MigrationFilterConfig,
                              pair_migration_type: PairMigrationConstraints) -> Callable[[InstanceInfo], bool]:
         return lambda instance_info: instance_info.num_killed_requests == 0 \
-            and instance_info.instance_load_migrate < filter_config.migrate_out_load_threshold
+            and instance_info.migration_load_metric < filter_config.migrate_out_load_threshold
 
 class PddFilter(MigrationFilterPolicy):
     INSTANCE_FILTER_RULES = {
@@ -102,7 +102,7 @@ class PddFilter(MigrationFilterPolicy):
             inner_policy = MigrationFilterPolicyFactory.get_policy('load')
             policy_filter = inner_policy.filter_src_condition(filter_config, pair_migration_type)
         else:
-            policy_filter = lambda instance_info: True
+            policy_filter = lambda _: True
 
         return lambda instance_info: instance_type_filter(instance_info) and policy_filter(instance_info)
 

--- a/llumnix/global_scheduler/migration_policy.py
+++ b/llumnix/global_scheduler/migration_policy.py
@@ -14,11 +14,10 @@
 from typing import List, Tuple
 from abc import ABC, abstractmethod
 from enum import Enum
-import copy
 import numpy as np
 
 from llumnix.logging.logger import init_logger
-from llumnix.instance_info import InstanceInfo, InstanceLoadCalculator
+from llumnix.instance_info import InstanceInfo
 
 logger = init_logger(__name__)
 
@@ -31,11 +30,8 @@ class PairMigrationConstraints(str, Enum):
     PREFILL_2_DECODING = "PREFILL_2_DECODING"
 
 class PairMigrationPolicy(ABC):
-    def __init__(self,
-                 migrate_out_load_threshold: float,
-                 instance_load_calculator: InstanceLoadCalculator) -> None:
+    def __init__(self, migrate_out_load_threshold: float) -> None:
         self.migrate_out_load_threshold = migrate_out_load_threshold
-        self.instance_load_calculator = instance_load_calculator
 
     @abstractmethod
     def pair_migration(self,
@@ -45,7 +41,7 @@ class PairMigrationPolicy(ABC):
         raise NotImplementedError
 
     def sort_instance_infos(self, instance_infos: List[InstanceInfo], descending: bool = True) -> None:
-        key_attr = 'instance_load_migrate'
+        key_attr = 'migration_load_metric'
         sorted_instance_infos = sorted(
             instance_infos,
             key=lambda instance_info: getattr(instance_info, key_attr),
@@ -62,32 +58,17 @@ class Balanced(PairMigrationPolicy):
         sorted_dst_instance_infos = self.sort_instance_infos(dst_instance_infos, descending=False)
         migrate_instance_pairs = []
         for i in range(min(len(sorted_src_instance_infos), len(sorted_dst_instance_infos))):
-            load_diff_before_mig = sorted_src_instance_infos[i].instance_load_migrate - sorted_dst_instance_infos[i].instance_load_migrate
-
-            left_load_after_mig = self._compute_instance_load_after_migrate(sorted_src_instance_infos[i], is_migrate_in=False)
-            right_load_after_mig = self._compute_instance_load_after_migrate(sorted_dst_instance_infos[i], is_migrate_in=True)
-
+            load_diff_before_mig = sorted_src_instance_infos[i].migration_load_metric - sorted_dst_instance_infos[i].migration_load_metric
+            left_load_after_mig = sorted_src_instance_infos[i].migration_load_metric_after_migrate_out
+            right_load_after_mig = sorted_dst_instance_infos[i].migration_load_metric_after_migrate_in
             # Add some constrains to reduce unnecessary migrations
             if right_load_after_mig > self.migrate_out_load_threshold:
                 continue
             load_diff_after_mig = left_load_after_mig - right_load_after_mig
-            if (0 < load_diff_after_mig < load_diff_before_mig) or (sorted_dst_instance_infos[i].instance_load_migrate == -np.inf):
+            if (0 < load_diff_after_mig < load_diff_before_mig) or (sorted_dst_instance_infos[i].migration_load_metric == -np.inf):
                 migrate_instance_pairs.append((sorted_src_instance_infos[i].instance_id,
                                                sorted_dst_instance_infos[i].instance_id))
         return migrate_instance_pairs
-
-    def _compute_instance_load_after_migrate(self, instance_info: InstanceInfo, is_migrate_in: bool) -> float:
-        instance_info_after_migrate = copy.deepcopy(instance_info)
-        num_blocks_last_running_request = instance_info_after_migrate.num_blocks_last_running_request
-
-        if is_migrate_in:
-            instance_info_after_migrate.num_running_requests += 1
-            instance_info_after_migrate.num_free_gpu_blocks -= num_blocks_last_running_request
-        else:
-            instance_info_after_migrate.num_running_requests -= 1
-            instance_info_after_migrate.num_free_gpu_blocks += num_blocks_last_running_request
-
-        return self.instance_load_calculator.compute_instance_load(instance_info_after_migrate, action='migrate')
 
 class DefragConstrained(PairMigrationPolicy):
     def pair_migration(self,

--- a/llumnix/instance_info.py
+++ b/llumnix/instance_info.py
@@ -12,7 +12,10 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import Dict
+import copy
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Tuple
 import numpy as np
 
 from llumnix.logging.logger import init_logger
@@ -20,139 +23,131 @@ from llumnix.llumlet.request import RequestInferenceType
 
 logger = init_logger(__name__)
 
+class InstanceType(str, Enum):
+    NO_CONSTRAINTS = "no_constraints"
+    PREFILL = "prefill"
+    DECODE = "decode"
 
+@dataclass
 class InstanceInfo:
-    def __init__(self,
-                 num_total_gpu_blocks: int = 0,
-                 num_watermark_blocks: int= 0,
-                 num_used_gpu_blocks: int = 0,
-                 num_free_gpu_blocks: int = 0,
-                 gpu_cache_usage: float = 0.0,
-                 num_running_requests: int = 0,
-                 num_waiting_requests: int = 0,
-                 num_killed_requests: int = 0,
-                 num_blocks_first_waiting_request: int = 0,
-                 waiting_time_first_waiting_request: int = 0,
-                 num_blocks_all_waiting_requests: int = 0,
-                 inference_type: RequestInferenceType = RequestInferenceType.PREFILL,
-                 instance_type: str = "",
-                 num_batched_tokens: int = 0,
-                 instance_id: str = "",) -> None:
-        self.num_total_gpu_blocks = num_total_gpu_blocks
-        self.num_watermark_blocks = num_watermark_blocks
-        self.num_used_gpu_blocks = num_used_gpu_blocks
-        self.num_free_gpu_blocks = num_free_gpu_blocks
+    instance_id: str = ""
+    instance_type: InstanceType = None
+
+    step_id: int = None
+    timestamp: float = None
+    num_batched_tokens: int = None
+    num_seqs = None
+    running_seq_lens: List[int] = field(default_factory=list)
+    last_inference_latency: float = None
+    inference_type: RequestInferenceType = None
+
+    num_total_gpu_blocks: int = 0
+    num_watermark_blocks: int = 0
+    num_used_gpu_blocks: int = 0
+    num_free_gpu_blocks: int = 0
+    gpu_cache_usage: float = 0.0
+    num_running_requests: int = 0
+    num_waiting_requests: int = 0
+    num_killed_requests: int = 0
+    num_blocks_first_waiting_request: int = 0
+    waiting_time_first_waiting_request: int = 0
+    num_blocks_all_waiting_requests: int = 0
+    num_blocks_last_running_request: int = 0
+
+    # on-demand init infos
+    dispatch_load_metric: float = -np.inf
+    migration_load_metric: float = np.inf
+    migration_load_metric_after_migrate_in: float = -np.inf
+    migration_load_metric_after_migrate_out: float = np.inf
+
+    # lazy init infos
+    num_available_gpu_blocks: int = 0
+    num_available_gpu_blocks_waiting: int = 0
+
+    # manual init infos
+    profiling_data: Tuple[str, int, int, float] = None
+
+    def __post_init__(self) -> None:
         self.num_available_gpu_blocks = self.num_free_gpu_blocks - self.num_watermark_blocks
-        self.gpu_cache_usage = gpu_cache_usage
-        self.num_running_requests = num_running_requests
-        self.num_waiting_requests = num_waiting_requests
-        self.num_killed_requests = num_killed_requests
-        self.num_blocks_first_waiting_request = num_blocks_first_waiting_request
-        self.waiting_time_first_waiting_request = waiting_time_first_waiting_request
-        self.num_blocks_all_waiting_requests = num_blocks_all_waiting_requests
         self.num_available_gpu_blocks_waiting = self.num_available_gpu_blocks - self.num_blocks_all_waiting_requests
-        # For instance load computation before migration.
-        self.num_blocks_last_running_request = 0
-
-        # For global scheduling.
-        self.instance_load_migrate = -np.inf
-        self.instance_load_dispatch_scale = -np.inf
-        self.instance_type = instance_type
-
-        # For record statistics, assigned in scheduler.
-        self.inference_type = inference_type
-        self.num_batched_tokens = num_batched_tokens
-        self.running_seq_lens = []
-        self.num_seqs = 0
-        self.max_tot_tokens = 0
-        self.finished_request_ids = None
-
-        # For record statistics, assigned in backend engine.
-        self.instance_id = instance_id
-        self.step_id = None
-        self.timestamp = None
-        self.profiling_data = ()
-
-class InstanceLoadInfo:
-    def __init__(self, instance_info: InstanceInfo) -> None:
-        self.num_total_gpu_blocks = instance_info.num_total_gpu_blocks
-        self.num_watermark_blocks = instance_info.num_watermark_blocks
-        self.num_used_gpu_blocks = instance_info.num_used_gpu_blocks
-        self.num_free_gpu_blocks = instance_info.num_free_gpu_blocks
-        self.num_available_gpu_blocks = instance_info.num_available_gpu_blocks
-
-        self.num_waiting_requests = instance_info.num_waiting_requests
-        self.num_running_requests = instance_info.num_running_requests
-        self.num_killed_requests = instance_info.num_killed_requests
-
-        self.num_blocks_first_waiting_request = instance_info.num_blocks_first_waiting_request
-        self.waiting_time_first_waiting_request = instance_info.waiting_time_first_waiting_request
-        self.num_blocks_all_waiting_requests = instance_info.num_blocks_all_waiting_requests
-
-        self.instance_id = instance_info.instance_id
-        self.step_id = instance_info.step_id
 
 class InstanceLoadCalculator:
-    def __init__(self,
-                 load_metric: str,
-                 enable_defrag: bool) -> None:
-        self.load_metric = load_metric
-        self.enable_defrag = enable_defrag
-        self.load_computation_strategies: Dict[str, LoadComputationStrategy] = {
-            'migrate': MigrationLoadComputation(load_metric, enable_defrag),
-            'dispatch': DispatchAndScalingLoadComputation(load_metric, enable_defrag),
-            'scale': DispatchAndScalingLoadComputation(load_metric, enable_defrag),
-        }
+    def __init__(self, dispatch_load_metric: str, migration_load_metric: str, enable_defrag: bool) -> None:
+        self.dispatch_load_calculator = DispatchLoadComputation(migration_load_metric)
+        self.migration_load_calculator = MigrationLoadComputation(dispatch_load_metric, enable_defrag)
 
-    def compute_instance_load(self,
-                              instance_info: InstanceInfo,
-                              action: str = 'migrate') -> float:
-        instance_load_info = InstanceLoadInfo(instance_info)
-        assert action in self.load_computation_strategies
-        load_computation_strategy = self.load_computation_strategies[action]
-        return load_computation_strategy.compute_instance_load(instance_load_info)
+    def compute_instance_load(self, instance_info: InstanceInfo):
+        instance_info.dispatch_load_metric = self.dispatch_load_calculator.compute_instance_load(instance_info)
+        instance_info.migration_load_metric = self.migration_load_calculator.compute_instance_load(instance_info)
+        instance_info.migration_load_metric_after_migrate_out = self.migration_load_calculator.\
+            compute_instance_load_after_migrate(instance_info, is_migrate_in=False)
+        instance_info.migration_load_metric_after_migrate_in = self.migration_load_calculator.\
+            compute_instance_load_after_migrate(instance_info, is_migrate_in=True)
 
 class LoadComputationStrategy(ABC):
-    def __init__(self,
-                 load_metric: str,
-                 enable_defrag: bool) -> None:
+    def __init__(self, load_metric: str, enable_defrag: bool = False) -> None:
         self.load_metric = load_metric
         self.enable_defrag = enable_defrag
 
     @abstractmethod
-    def compute_instance_load(self, i: InstanceLoadInfo) -> float:
+    def compute_instance_load(self, instance_info: InstanceInfo) -> float:
         pass
 
-class MigrationLoadComputation(LoadComputationStrategy):
-    def compute_instance_load(self, i: InstanceLoadInfo) -> float:
+class DispatchLoadComputation(LoadComputationStrategy):
+    def compute_instance_load(self, instance_info: InstanceInfo) -> float:
         instance_load = -np.inf
         if self.load_metric == 'usage_ratio':
-            instance_load = (i.num_used_gpu_blocks + i.num_blocks_first_waiting_request) / i.num_total_gpu_blocks
+            instance_load = (instance_info.num_used_gpu_blocks + instance_info.num_blocks_all_waiting_requests) \
+                / instance_info.num_total_gpu_blocks
         elif self.load_metric == 'remaining_steps':
-            if not self.enable_defrag:
-                num_requests = i.num_running_requests
-                num_available_gpu_blocks = i.num_available_gpu_blocks
-            else:
-                num_requests = i.num_running_requests
-                if i.num_waiting_requests != 0:
-                    num_requests += 1
-                    # num_requests = i.num_running_requests + i.num_waiting_requests
-                num_available_gpu_blocks = i.num_available_gpu_blocks - i.num_blocks_first_waiting_request
-                # num_available_gpu_blocks = i.num_available_gpu_blocks - i.num_blocks_all_waiting_requests
+            num_requests = instance_info.num_running_requests + instance_info.num_waiting_requests
+            num_available_gpu_blocks = instance_info.num_available_gpu_blocks - instance_info.num_blocks_all_waiting_requests
             if num_requests == 0:
                 return -np.inf
             instance_load = (num_available_gpu_blocks / num_requests)*(-1)
         return instance_load
 
-class DispatchAndScalingLoadComputation(LoadComputationStrategy):
-    def compute_instance_load(self, i: InstanceLoadInfo) -> float:
+class MigrationLoadComputation(LoadComputationStrategy):
+    def compute_instance_load_after_migrate(self, instance_info: InstanceInfo, is_migrate_in: bool) -> float:
+        instance_info_after_migrate = copy.deepcopy(instance_info)
+        num_blocks_last_running_request = instance_info_after_migrate.num_blocks_last_running_request
+
+        if is_migrate_in:
+            instance_info_after_migrate.num_running_requests += 1
+            instance_info_after_migrate.num_available_gpu_blocks -= num_blocks_last_running_request
+        else:
+            instance_info_after_migrate.num_running_requests -= 1
+            instance_info_after_migrate.num_available_gpu_blocks += num_blocks_last_running_request
+
+        return self.compute_instance_load(instance_info_after_migrate)
+
+    def compute_instance_load(self, instance_info: InstanceInfo) -> float:
         instance_load = -np.inf
         if self.load_metric == 'usage_ratio':
-            instance_load = (i.num_used_gpu_blocks + i.num_blocks_all_waiting_requests) / i.num_total_gpu_blocks
+            instance_load = (instance_info.num_used_gpu_blocks + instance_info.num_blocks_first_waiting_request) \
+                / instance_info.num_total_gpu_blocks
         elif self.load_metric == 'remaining_steps':
-            num_requests = i.num_running_requests + i.num_waiting_requests
-            num_available_gpu_blocks = i.num_available_gpu_blocks - i.num_blocks_all_waiting_requests
+            if not self.enable_defrag:
+                num_requests = instance_info.num_running_requests
+                num_available_gpu_blocks = instance_info.num_available_gpu_blocks
+            else:
+                num_requests = instance_info.num_running_requests
+                if instance_info.num_waiting_requests != 0:
+                    num_requests += 1
+                num_available_gpu_blocks = instance_info.num_available_gpu_blocks - \
+                    instance_info.num_blocks_first_waiting_request
             if num_requests == 0:
                 return -np.inf
-            instance_load = (num_available_gpu_blocks / num_requests)*(-1)
+            instance_load = (num_available_gpu_blocks / num_requests) * (-1)
         return instance_load
+
+# TODO(KuilongCui): currently scaling and dispatch use the same load calculator, leave
+# it in the future to refine
+class ScalingLoadComputation(LoadComputationStrategy):
+    def __init__(self, load_metric):
+        super().__init__(load_metric)
+        self.load_calculator = DispatchLoadComputation(load_metric)
+
+    def compute_instance_load(self, instance_info: InstanceInfo) -> float:
+        return self.load_calculator.compute_instance_load(instance_info)
+    

--- a/llumnix/internal_config.py
+++ b/llumnix/internal_config.py
@@ -18,8 +18,8 @@ class MigrationConfig:
             migration_backend: str,
             migration_buffer_blocks: int,
             migration_num_layers: int,
-            last_stage_max_blocks: int,
-            max_stages: int,
+            migration_last_stage_max_blocks: int,
+            migration_max_stages: int,
             migration_backend_init_timeout: float,
             migration_backend_transfer_type: str = "",
             grpc_migration_backend_server_address: str = "",
@@ -30,8 +30,8 @@ class MigrationConfig:
         self.migration_backend_transfer_type = migration_backend_transfer_type
         self.migration_num_layers = migration_num_layers
         self.migration_buffer_blocks = migration_buffer_blocks
-        self.last_stage_max_blocks = last_stage_max_blocks
-        self.max_stages = max_stages
+        self.migration_last_stage_max_blocks = migration_last_stage_max_blocks
+        self.migration_max_stages = migration_max_stages
         self.migration_backend_init_timeout = migration_backend_init_timeout
         self.grpc_migration_backend_server_address = grpc_migration_backend_server_address
         self.kvtransfer_migration_backend_naming_url = kvtransfer_migration_backend_naming_url
@@ -41,33 +41,24 @@ class GlobalSchedulerConfig:
     def __init__(
             self,
             initial_instances: int,
-            load_metric: str,
             dispatch_policy: str,
-            num_dispatch_instances: int,
             pair_migration_policy: str,
             migrate_out_threshold: float,
-            enable_defrag: bool,
             scaling_policy: str,
+            scaling_load_metric: str,
             scale_up_threshold: float,
             scale_down_threshold: float,
             enable_pd_disagg: bool,
-            migration_backend: str,) -> None:
+            is_group_kind_migration_backend: bool,) -> None:
         self.initial_instances = initial_instances
-        self.load_metric = load_metric
-
         self.dispatch_policy = dispatch_policy
-
         self.pair_migration_policy = pair_migration_policy
-        # TODO(KuilongCui): Use a better way to set the threshold, as having both positive and negative
-        # values can cause confusion.
-        self.migrate_out_load_threshold = migrate_out_threshold*(-1)
-        self.enable_defrag = enable_defrag
+        self.migrate_out_load_threshold = migrate_out_threshold
 
         self.scaling_policy = scaling_policy
-        self.scale_up_threshold = scale_up_threshold*(-1)
-        self.scale_down_threshold = scale_down_threshold*(-1)
+        self.scaling_load_metric = scaling_load_metric
+        self.scale_up_threshold = scale_up_threshold
+        self.scale_down_threshold = scale_down_threshold
 
         self.enable_pd_disagg = enable_pd_disagg
-        self.num_dispatch_instances = num_dispatch_instances
-
-        self.migration_backend = migration_backend
+        self.is_group_kind_migration_backend = is_group_kind_migration_backend

--- a/llumnix/launcher.py
+++ b/llumnix/launcher.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2024, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import copy
+import traceback
+from typing import Callable, Dict, List, Tuple
+
+import ray
+from ray.util.state import list_placement_groups, list_actors
+from ray.util.placement_group import PlacementGroup
+
+from llumnix.logging.logger import init_logger
+from llumnix.instance_info import InstanceType
+from llumnix.global_scheduler.global_scheduler import GlobalScheduler
+from llumnix.llumlet.llumlet import Llumlet
+from llumnix.queue.queue_type import QueueType
+from llumnix.backends.backend_interface import BackendType
+from llumnix.arg_utils import EntrypointsArgs, InstanceArgs
+from llumnix.entrypoints.vllm.api_server_actor import APIServerActor
+from llumnix.backends.utils import get_engine_world_size
+from llumnix.utils import (remove_placement_group, get_manager_name, INSTANCE_NAME_PREFIX, get_instance_name,
+                           SERVER_NAME_PREFIX, kill_server, kill_instance, get_actor_data_from_ray_internal_kv,
+                           initialize_placement_group, get_server_name, put_actor_data_to_ray_internal_kv,
+                           get_placement_group_name)
+
+logger = init_logger(__name__)
+
+class Launcher:
+    def __init__(self, global_scheduler: GlobalScheduler, enable_port_increment: bool,
+                 enable_port_offset_store: bool, enable_pd_disagg: bool,
+                 enablde_engine_pd_disagg: bool, pd_ratio: List[int]):
+        self.global_scheduler = global_scheduler
+        self.enable_port_increment = enable_port_increment
+        self.enable_port_offset_store = enable_port_offset_store
+        self.enable_pd_disagg = enable_pd_disagg
+        self.enablde_engine_pd_disagg = enablde_engine_pd_disagg
+        self.pd_ratio = pd_ratio
+
+        if enable_port_increment:
+            self.port_offset = 0
+            if enable_port_offset_store:
+                value = get_actor_data_from_ray_internal_kv("manager", "port_offset")
+                if value is not None:
+                    self.port_offset = int(value)
+
+        self.inflight_num_prefill = 0
+        self.inflight_num_decode = 0
+
+    def init_placement_group(self,
+                              placement_group_name: str,
+                              engine_args,
+                              backend_type: BackendType,
+                              init_server: bool = False,
+                              block: bool = True) -> PlacementGroup:
+        if not BackendType.is_sim_backend(backend_type):
+            # num_cpus=3, for Llumlet + AsyncPutQueueActor + ProxyActor
+            # num_gpus=world_size, for world_size Workers
+            world_size = get_engine_world_size(engine_args, backend_type)
+            placement_group = initialize_placement_group(placement_group_name, num_cpus=3+int(init_server),
+                                                         num_gpus=world_size, detached=True, block=block)
+        else:
+            # num_cpus=1, for Llumlet + AsyncPutQueueActor
+            placement_group = initialize_placement_group(placement_group_name, num_cpus=2+int(init_server),
+                                                         num_gpus=0, detached=True, block=block)
+
+        return placement_group
+
+    def get_instance_deployment_states(self, instance_id: str):
+        pg_state = list_placement_groups(filters=[("name", "=", get_placement_group_name(instance_id))])
+        pg_created = len(pg_state) == 1 and pg_state[0]["state"] == "CREATED"
+        server_state = list_actors(filters=[("name", "=", get_server_name(instance_id))])
+        server_alive = len(server_state) == 1 and server_state[0]["state"] == "ALIVE"
+        instance_state = list_actors(filters=[("name", "=", get_instance_name(instance_id))])
+        instance_alive = len(instance_state) == 1 and instance_state[0]["state"] == "ALIVE"
+
+        return pg_created, server_alive, instance_alive
+
+    def get_cluster_deployment(self) -> Tuple[Dict[str, PlacementGroup], Dict[str, APIServerActor], Dict[str, Llumlet]]:
+        curr_pgs: Dict[str, PlacementGroup] = {}
+        curr_servers: Dict[str, PlacementGroup] = {}
+        curr_instances: Dict[str, Llumlet] = {}
+
+        created_pg_states = list_placement_groups(filters=[("state", "=", "CREATED")])
+        for created_pg_state in created_pg_states:
+            instance_id = created_pg_state["name"].split("_")[-1]
+            curr_pgs[instance_id] = ray.util.get_placement_group(created_pg_state["name"])
+
+        alive_actor_states = list_actors(filters=[("state", "=", "ALIVE")])
+        for alive_actor_state in alive_actor_states:
+            if alive_actor_state["name"].startswith(SERVER_NAME_PREFIX):
+                instance_id = alive_actor_state["name"].split("_")[-1]
+                curr_servers[instance_id] = ray.get_actor(alive_actor_state["name"], namespace="llumnix")
+            elif alive_actor_state["name"].startswith(INSTANCE_NAME_PREFIX):
+                instance_id = alive_actor_state["name"].split("_")[-1]
+                curr_instances[instance_id] = ray.get_actor(alive_actor_state["name"], namespace="llumnix")
+
+        return curr_pgs, curr_servers, curr_instances
+
+    def clear_instance_ray_resources(self, instance_id: str):
+        if not remove_placement_group(instance_id):
+            logger.debug("Failed to remove placement group {}.".format(instance_id))
+        if not kill_server(instance_id):
+            logger.debug("Failed to kill server {}.".format(instance_id))
+        if not kill_instance(instance_id):
+            logger.debug("Failed to kill instance {}.".format(instance_id))
+
+    def _get_next_instance_type(self, cur_num_prefill, cur_num_decode, pd_ratio) -> str:
+        instance_type = InstanceType.NO_CONSTRAINTS
+
+        if self.enable_pd_disagg:
+            # Note: There are no instances simultaneously in inflight_num_prefill and cur_num_prefill as
+            # inflight_num will decrease before scaling up the instances. The same applies to num_decode.
+            total_num_prefill = self.inflight_num_prefill + cur_num_prefill
+            total_num_decode = self.inflight_num_decode + cur_num_decode
+
+            if total_num_prefill == 0:
+                instance_type = InstanceType.PREFILL
+            elif total_num_decode == 0:
+                instance_type = InstanceType.DECODE
+            else:
+                # compute distance if launch prefill or decode
+                normal_distance = pd_ratio[0] - pd_ratio[1]
+
+                base_num_ratio = min(total_num_prefill//pd_ratio[0], total_num_decode//pd_ratio[1])
+                total_num_prefill = total_num_prefill - base_num_ratio * pd_ratio[0]
+                total_num_decode = total_num_decode - base_num_ratio * pd_ratio[1]
+
+                if total_num_prefill + total_num_decode == 0:
+                    instance_type = InstanceType.PREFILL
+                else:
+                    distance_if_prefill = total_num_prefill + 1 - total_num_decode
+                    distance_if_decode = total_num_prefill - (total_num_decode + 1)
+                    gap_to_normal_if_prefill = abs(distance_if_prefill - normal_distance)
+                    gap_to_normal_if_decode = abs(distance_if_decode - normal_distance)
+                    instance_type = InstanceType.PREFILL if gap_to_normal_if_prefill <= gap_to_normal_if_decode \
+                        else InstanceType.DECODE
+
+        return instance_type
+
+    def _get_next_instance_args(self, instance_args) -> InstanceArgs:
+        assert not self.enablde_engine_pd_disagg, \
+            "Currently not support engine based pd-disaggregation in global launch mode."
+
+        config: InstanceArgs = copy.deepcopy(instance_args)
+        cur_num_prefill = len(self.global_scheduler.dispatch_scheduler.available_dispatch_instance_set)
+        cur_num_decode = len(self.global_scheduler.instance_id_set -
+                                self.global_scheduler.dispatch_scheduler.available_dispatch_instance_set)
+        config.instance_type = self._get_next_instance_type(cur_num_prefill, cur_num_decode, self.pd_ratio)
+        return config
+
+    def _get_next_entrypoints_args(self, entrypoints_args: EntrypointsArgs) -> EntrypointsArgs:
+        config = copy.deepcopy(entrypoints_args)
+        if self.enable_port_increment:
+            config.port += self.port_offset
+            config.request_output_queue_port += self.port_offset
+            self.port_offset += 1
+            if self.enable_port_offset_store:
+                put_actor_data_to_ray_internal_kv("manager", "port_offset", self.port_offset)
+        return config
+
+    def init_server_and_instance(self, instance_id: str, entrypoints_args: EntrypointsArgs,
+                                 instance_args: InstanceArgs, engine_args, backend_type: BackendType,
+                                 placement_group: PlacementGroup, instance_finish_cb: Callable = None,
+                                 server_finish_cb: Callable = None):
+        async def done_scale_up(instance_args: InstanceArgs, entrypoint_args: EntrypointsArgs):
+            try:
+                manager = ray.get_actor(get_manager_name(), namespace="llumnix")
+                await instance.is_ready.remote()
+                await server.run.remote(manager, instance_id, instance)
+                self.inflight_num_prefill -= 1 if instance_args.instance_type == InstanceType.PREFILL else 0
+                self.inflight_num_decode -= 1 if instance_args.instance_type == InstanceType.DECODE else 0
+                if instance_finish_cb:
+                    # manager.scale_up will be called here after the instance is ready
+                    instance_finish_cb(instance_id, instance, instance_args)
+                if server_finish_cb:
+                    server_finish_cb(instance_id, server)
+                logger.info("Launcher init_server_and_instance done, instance_id: {}, instance_type: {}, "
+                            "api_server_port: {}, request_output_queue_port: {}".format(instance_id,
+                            instance_args.instance_type, entrypoint_args.port,
+                            entrypoint_args.request_output_queue_port))
+            # pylint: disable=broad-except
+            except Exception as e:
+                self.inflight_num_prefill -= 1 if instance_args.instance_type == InstanceType.PREFILL else 0
+                self.inflight_num_decode -= 1 if instance_args.instance_type == InstanceType.DECODE else 0
+                logger.error("Unexpected exception occurs: {}".format(e))
+                logger.error("Exception traceback: {}".format(traceback.format_exc()))
+                self.clear_instance_ray_resources(instance_id)
+
+        request_output_queue_type = QueueType(entrypoints_args.request_output_queue_type)
+        next_instance_args = self._get_next_instance_args(instance_args)
+        instance = self.init_instance(instance_id, next_instance_args, placement_group,
+                                       request_output_queue_type, backend_type, engine_args)
+        next_entrypoints_args = self._get_next_entrypoints_args(entrypoints_args)
+        server = self.init_server(get_server_name(instance_id), placement_group, next_entrypoints_args)
+
+        self.inflight_num_prefill += 1 if next_instance_args.instance_type == InstanceType.PREFILL else 0
+        self.inflight_num_decode += 1 if next_instance_args.instance_type == InstanceType.DECODE else 0
+        asyncio.create_task(done_scale_up(next_instance_args, next_entrypoints_args))
+
+    def init_server(self, server_name: str, placement_group: PlacementGroup,
+                    entrypoints_args: EntrypointsArgs) -> APIServerActor:
+        fastapi_server = APIServerActor.from_args(server_name, placement_group, entrypoints_args)
+        return fastapi_server
+
+    def init_instance(self,
+                       instance_id: str,
+                       instance_args: InstanceArgs,
+                       placement_group: PlacementGroup,
+                       request_output_queue_type: QueueType,
+                       backend_type: BackendType,
+                       engine_args
+                      ) -> Tuple[str, Llumlet]:
+        instance = Llumlet.from_args(
+                        instance_id,
+                        instance_args,
+                        placement_group,
+                        request_output_queue_type,
+                        backend_type,
+                        engine_args)
+
+        return instance

--- a/llumnix/launcher.py
+++ b/llumnix/launcher.py
@@ -152,22 +152,22 @@ class Launcher:
         assert not self.enablde_engine_pd_disagg, \
             "Currently not support engine based pd-disaggregation in global launch mode."
 
-        config: InstanceArgs = copy.deepcopy(instance_args)
+        next_instance_args: InstanceArgs = copy.deepcopy(instance_args)
         cur_num_prefill = len(self.global_scheduler.dispatch_scheduler.available_dispatch_instance_set)
         cur_num_decode = len(self.global_scheduler.instance_id_set -
                                 self.global_scheduler.dispatch_scheduler.available_dispatch_instance_set)
-        config.instance_type = self._get_next_instance_type(cur_num_prefill, cur_num_decode, self.pd_ratio)
-        return config
+        next_instance_args.instance_type = self._get_next_instance_type(cur_num_prefill, cur_num_decode, self.pd_ratio)
+        return next_instance_args
 
     def _get_next_entrypoints_args(self, entrypoints_args: EntrypointsArgs) -> EntrypointsArgs:
-        config = copy.deepcopy(entrypoints_args)
+        next_entrypoints_args = copy.deepcopy(entrypoints_args)
         if self.enable_port_increment:
-            config.port += self.port_offset
-            config.request_output_queue_port += self.port_offset
+            next_entrypoints_args.port += self.port_offset
+            next_entrypoints_args.request_output_queue_port += self.port_offset
             self.port_offset += 1
             if self.enable_port_offset_store:
                 put_actor_data_to_ray_internal_kv("manager", "port_offset", self.port_offset)
-        return config
+        return next_entrypoints_args
 
     def init_server_and_instance(self, instance_id: str, entrypoints_args: EntrypointsArgs,
                                  instance_args: InstanceArgs, engine_args, backend_type: BackendType,

--- a/llumnix/manager.py
+++ b/llumnix/manager.py
@@ -12,17 +12,18 @@
 # limitations under the License.
 
 import asyncio
+import random
 import time
 import csv
-import copy
 import os
 from typing import Dict, List, Tuple, Union, Iterable
 from collections import defaultdict
 import traceback
 from functools import partial
+
 import ray
+import ray.actor
 from ray.util.state import list_placement_groups, list_actors
-from ray.util.placement_group import PlacementGroup
 
 from llumnix.llumlet.llumlet import Llumlet
 from llumnix.logging.logger import init_logger
@@ -30,24 +31,19 @@ from llumnix.global_scheduler.global_scheduler import GlobalScheduler
 from llumnix.global_scheduler.migration_scheduler import PairMigrationConstraints
 from llumnix.global_scheduler.migration_filter import CustomFilter
 from llumnix.instance_info import InstanceInfo
-from llumnix.arg_utils import ManagerArgs, EntrypointsArgs, LaunchArgs
+from llumnix.arg_utils import ManagerArgs, EntrypointsArgs, InstanceArgs, LaunchArgs
 from llumnix.server_info import ServerInfo
 from llumnix.backends.backend_interface import BackendType
-from llumnix.utils import (random_uuid, clear_gloo_backend_state, remove_placement_group,
-                           get_instance_name, get_manager_name, INSTANCE_NAME_PREFIX,
-                           SERVER_NAME_PREFIX, get_placement_group_name, run_async_func_sync,
-                           kill_server, kill_instance, initialize_placement_group,
-                           get_server_name, get_actor_data_from_ray_internal_kv,
-                           put_actor_data_to_ray_internal_kv)
+from llumnix.utils import (random_uuid, clear_gloo_backend_state, get_instance_name,
+                           get_manager_name, INSTANCE_NAME_PREFIX, get_placement_group_name,
+                           run_async_func_sync,)
 from llumnix.entrypoints.utils import LaunchMode
-from llumnix.backends.utils import get_engine_world_size
 from llumnix.queue.queue_type import QueueType
-from llumnix.entrypoints.vllm.api_server_actor import APIServerActor
 from llumnix.constants import (CLEAR_REQUEST_INSTANCE_INTERVAL, NO_INSTANCE_RETRY_INTERVAL,
                                WAIT_ALL_MIGRATIONS_DONE_INTERVAL, AUTO_SCALE_UP_INTERVAL,
                                WAIT_PLACEMENT_GROUP_TIMEOUT, CHECK_DEPLOYMENT_STATES_INTERVAL,
                                WATCH_DEPLOYMENT_INTERVAL, WATCH_DEPLOYMENT_INTERVAL_PENDING_INSTANCE)
-
+from llumnix.launcher import Launcher
 
 logger = init_logger(__name__)
 
@@ -56,11 +52,12 @@ logger = init_logger(__name__)
 
 class Manager:
     def __init__(self,
+                 entrypoints_args: EntrypointsArgs,
                  manager_args: ManagerArgs,
+                 instance_args: InstanceArgs,
+                 engine_args,
+                 launch_args: LaunchArgs,
                  work_dir: str,
-                 entrypoints_args: EntrypointsArgs = None,
-                 engine_args = None,
-                 launch_args: LaunchArgs = None
                  ) -> None:
         os.chdir(work_dir)
         self.job_id = ray.get_runtime_context().get_job_id()
@@ -71,8 +68,10 @@ class Manager:
                         self.job_id, self.worker_id, self.actor_id, self.node_id))
         self.actor_name = get_manager_name()
         self.manager_args = manager_args
-        # engine_args and entrypoints_args are used in global deployment.
+
+        # used in global deployment.
         self.entrypoints_args = entrypoints_args
+        self.instance_args = instance_args
         self.engine_args = engine_args
         self.launch_args = launch_args
 
@@ -97,8 +96,13 @@ class Manager:
 
         self.polling_interval = manager_args.polling_interval
 
-        global_scheduler_config = manager_args.create_global_scheduler_config()
+        self.is_group_kind_migration_backend = manager_args.is_group_kind_migration_backend
+        global_scheduler_config = manager_args.create_global_scheduler_config(self.is_group_kind_migration_backend)
         self.global_scheduler = GlobalScheduler(global_scheduler_config)
+
+        self.launcher: Launcher = Launcher(self.global_scheduler, manager_args.enable_port_increment,
+                                           manager_args.enable_port_offset_store, manager_args.enable_pd_disagg,
+                                           manager_args.enable_engine_pd_disagg, manager_args.pd_ratio)
 
         # log args
         self.log_requests = not manager_args.disable_log_requests_manager
@@ -133,17 +137,13 @@ class Manager:
         asyncio.create_task(self._update_instance_info_loop(self.polling_interval))
         asyncio.create_task(self._clear_request_instance_loop(CLEAR_REQUEST_INSTANCE_INTERVAL))
 
-        if self.manager_args.enable_port_increment:
-            self.port_offset = 0
-            if self.manager_args.enable_port_offset_store:
-                value = get_actor_data_from_ray_internal_kv("manager", "port_offset")
-                if value is not None:
-                    self.port_offset = int(value)
         if hasattr(self, "launch_mode") and self.launch_mode == LaunchMode.GLOBAL:
             assert self.entrypoints_args is not None and self.engine_args is not None
             self.last_timeout_instance_id = None
             asyncio.create_task(self._auto_scale_up_loop(AUTO_SCALE_UP_INTERVAL))
             asyncio.create_task(self._check_deployment_states_loop(CHECK_DEPLOYMENT_STATES_INTERVAL))
+            if self.manager_args.enable_pd_disagg:
+                asyncio.create_task(self._check_pd_deployment_states_loop(CHECK_DEPLOYMENT_STATES_INTERVAL))
 
     async def generate(self, request_id: str, server_info: ServerInfo, *args, **kwargs,) -> None:
         while self.num_instances == 0:
@@ -312,7 +312,7 @@ class Manager:
                     self.scale_down(instance_id)
                 if new_pg is None:
                     new_instance_id = random_uuid()
-                    new_pg = self._init_placement_group(get_placement_group_name(new_instance_id), self.engine_args, self.backend_type,
+                    new_pg = self.launcher.init_placement_group(get_placement_group_name(new_instance_id), self.engine_args, self.backend_type,
                                                         init_server=True, block=False)
                 try:
                     await asyncio.wait_for(new_pg.ready(), WAIT_PLACEMENT_GROUP_TIMEOUT)
@@ -323,7 +323,9 @@ class Manager:
                     self.last_timeout_instance_id = new_instance_id
                     await asyncio.sleep(interval)
                     continue
-                self._init_server_and_instance(new_instance_id, new_pg)
+                self.launcher.init_server_and_instance(new_instance_id, self.entrypoints_args, self.instance_args,
+                                                       self.engine_args, self.backend_type, new_pg,
+                                                       instance_finish_cb=self.scale_up)
                 logger.info("Deploy server and instance to new placement group done, instance_id: {}.".format(new_instance_id))
             # pylint: disable=broad-except
             except Exception as e:
@@ -352,16 +354,13 @@ class Manager:
                     dead_instances.add(instance_name)
             if len(dead_instances) > 0:
                 self.scale_down(dead_instances, rebuild_migration_backend=False)
-                if self.manager_args.migration_backend == 'gloo':
-                    clear_gloo_backend_state()
+                clear_gloo_backend_state()
             return dead_instances
 
         alive_instances = sorted(self.instances.keys())
         pending_task = self.pending_rebuild_migration_instances
         group_name = None
-
-        if self.manager_args.migration_backend == 'gloo':
-            clear_gloo_backend_state()
+        clear_gloo_backend_state()
 
         while len(alive_instances) > 0 and self.pending_rebuild_migration_instances > 0:
             dead_instances = set()
@@ -386,20 +385,22 @@ class Manager:
             src_filter=lambda instance_info: instance_info.instance_id in alive_instances,
             dst_filter=lambda instance_info: instance_info.instance_id in alive_instances)
 
-        logger.info("Rebuild {} migration backend done, group_name: {}, alive instance ({}): {}."
-            .format(self.manager_args.migration_backend, group_name, len(alive_instances), alive_instances))
+        logger.info("Rebuild migration backend done, group_name: {}, alive instance ({}): {}."
+            .format(group_name, len(alive_instances), alive_instances))
 
         # Restore migrate config
         self.enable_migration = origin_config
 
-    def scale_up(self,
-                 instance_id: Union[str, Iterable[str]],
-                 instance_actor_handle: Union["ray.actor.ActorHandle", List["ray.actor.ActorHandle"]]) -> None:
+    def scale_up(self, instance_id: Union[str, Iterable[str]],
+                 instance_actor_handle: Union[ray.actor.ActorHandle, List[ray.actor.ActorHandle]],
+                 instance_arg: Union[InstanceArgs, Iterable[InstanceArgs]]) -> None:
         if isinstance(instance_id, str):
             instance_id = [instance_id,]
             instance_actor_handle = [instance_actor_handle,]
+            instance_arg = [instance_arg,]
         instance_ids = list(instance_id)
         instance_actor_handles = list(instance_actor_handle)
+        instance_args = list(instance_arg)
 
         indeed_update = False
         no_pending_instance = (self.pending_rebuild_migration_instances == 0)
@@ -412,14 +413,14 @@ class Manager:
                 if self.log_instance_info:
                     self.instance_last_logged_empty[ins_id] = False
                 self.pending_rebuild_migration_instances += 1
-        self.global_scheduler.scale_up(instance_ids)
+        self.global_scheduler.scale_up(instance_ids, instance_args)
         self.num_instances = len(self.instances)
 
         # When scaling up, we need to rebuild the migration backend. But if initially self.pending_rebuild_migration_instances != 0,
         # a coroutine is already handling the changes in the number of instances in the cluster and it will account for the changes
         # caused by this scale-up (see rebuild_migration_backend for details). Therefore, we simply return in this case.
-        # Specifically, for RayRPC migration backend, the Ray actor handle is used for the migration cache, so there is no need to rebuild the group.
-        if self.enable_migration and self.manager_args.migration_backend in ['gloo', 'nccl'] \
+        # Specifically, for not group kind migration backend, there is no need to rebuild the group.
+        if self.enable_migration and self.is_group_kind_migration_backend \
             and indeed_update and no_pending_instance:
             asyncio.create_task(self._rebuild_migration_backend())
 
@@ -434,7 +435,7 @@ class Manager:
         no_pending_instance = self.pending_rebuild_migration_instances == 0
 
         for ins_id in instance_ids:
-            self._clear_instance_ray_states(ins_id)
+            self.launcher.clear_instance_ray_resources(ins_id)
             if ins_id in self.instances:
                 indeed_update = True
                 if ins_id in self.instances:
@@ -454,23 +455,14 @@ class Manager:
         self.global_scheduler.scale_down(instance_ids)
         self.num_instances = len(self.instances)
 
-        if self.enable_migration and self.manager_args.migration_backend in ['gloo', 'nccl']:
+        if self.enable_migration and self.is_group_kind_migration_backend:
             if len(self.instances) == 0:
                 self.pending_rebuild_migration_instances = 0
-                if self.manager_args.migration_backend == 'gloo':
-                    clear_gloo_backend_state()
+                clear_gloo_backend_state()
             elif indeed_update and no_pending_instance and rebuild_migration_backend:
                 asyncio.create_task(self._rebuild_migration_backend())
 
         return self.num_instances
-
-    def _clear_instance_ray_states(self, instance_id: str):
-        if not remove_placement_group(instance_id):
-            logger.debug("Failed to remove placement group {}.".format(instance_id))
-        if not kill_server(instance_id):
-            logger.debug("Failed to kill server {}.".format(instance_id))
-        if not kill_instance(instance_id):
-            logger.debug("Failed to kill instance {}.".format(instance_id))
 
     async def _connect_to_instances(self):
         def connect_to_instances_done_callback(instance_id: str, instance_actor_handle: "ray.actor.ActorHandle", fut):
@@ -478,6 +470,7 @@ class Manager:
             if not isinstance(ret, Exception):
                 scale_up_instance_ids.append(instance_id)
                 scale_up_instance_actor_handles.append(instance_actor_handle)
+                scale_up_instance_args.append(ret)
                 logger.info("Connect to instance {}".format(instance_id))
             else:
                 logger.warning("Connect to instance {} failed, exception: {}".format(instance_id, ret))
@@ -489,125 +482,109 @@ class Manager:
         instance_actor_handles = [ray.get_actor(actor_name, namespace='llumnix') for actor_name in instance_actor_names]
         scale_up_instance_ids = []
         scale_up_instance_actor_handles = []
+        scale_up_instance_args = []
         tasks = []
         for instance_actor_name, instance_actor_handle in zip(instance_actor_names, instance_actor_handles):
             instance_id = instance_actor_name[len('instance_'):]
             if instance_id not in self.instances:
-                task = asyncio.gather(instance_actor_handle.is_ready.remote(), return_exceptions=True)
+                task = asyncio.gather(instance_actor_handle.get_instance_args.remote(), return_exceptions=True)
                 task.add_done_callback(partial(connect_to_instances_done_callback, instance_id, instance_actor_handle))
                 tasks.append(task)
         await asyncio.gather(*tasks)
         # The only function that can add instance actor handles to manager.
-        self.scale_up(scale_up_instance_ids, scale_up_instance_actor_handles)
+        self.scale_up(scale_up_instance_ids, scale_up_instance_actor_handles, scale_up_instance_args)
 
     @classmethod
     def from_args(cls,
+                  entrypoints_args: EntrypointsArgs,
                   manager_args: ManagerArgs,
-                  entrypoints_args: EntrypointsArgs = None,
-                  engine_args = None,
-                  launch_args: LaunchArgs = None,
+                  instance_args: InstanceArgs,
+                  engine_args,
+                  launch_args: LaunchArgs,
                   ) -> "Manager":
         manager_class = ray.remote(num_cpus=1,
                                    max_restarts=-1,
                                    name=get_manager_name(),
                                    namespace="llumnix",
                                    lifetime="detached")(cls)
-        manager = manager_class.remote(manager_args,
-                                       os.getcwd(),
-                                       entrypoints_args,
-                                       engine_args,
-                                       launch_args)
-
+        manager = manager_class.remote(
+            entrypoints_args,
+            manager_args,
+            instance_args,
+            engine_args,
+            launch_args,
+            os.getcwd())
         return manager
-
-    def _init_placement_group(self,
-                              placement_group_name: str,
-                              engine_args,
-                              backend_type: BackendType,
-                              init_server: bool = False,
-                              block: bool = True) -> PlacementGroup:
-        if not BackendType.is_sim_backend(backend_type):
-            # num_cpus=3, for Llumlet + AsyncPutQueueActor + ProxyActor
-            # num_gpus=world_size, for world_size Workers
-            world_size = get_engine_world_size(engine_args, backend_type)
-            placement_group = initialize_placement_group(placement_group_name,
-                                                         num_cpus=3+int(init_server), num_gpus=world_size, detached=True, block=block)
-        else:
-            # num_cpus=1, for Llumlet + AsyncPutQueueActor
-            placement_group = initialize_placement_group(placement_group_name,
-                                                         num_cpus=2+int(init_server), num_gpus=0, detached=True, block=block)
-
-        return placement_group
-
-    def _init_server(self,
-                     server_name: str,
-                     placement_group: PlacementGroup,
-                     entrypoints_args: EntrypointsArgs) -> APIServerActor:
-        entrypoints_args = copy.deepcopy(entrypoints_args)
-        if self.manager_args.enable_port_increment:
-            entrypoints_args.port += self.port_offset
-            entrypoints_args.request_output_queue_port += self.port_offset
-            self.port_offset += 1
-            if self.manager_args.enable_port_offset_store:
-                put_actor_data_to_ray_internal_kv("manager", "port_offset", self.port_offset)
-        api_server = APIServerActor.from_args(server_name, placement_group, entrypoints_args)
-        return api_server
-
-    def _init_instance(self,
-                       instance_id: str,
-                       placement_group: PlacementGroup,
-                       request_output_queue_type: QueueType,
-                       backend_type: BackendType,
-                       engine_args
-                      ) -> Tuple[str, Llumlet]:
-        instance = Llumlet.from_args(
-                        instance_id,
-                        placement_group,
-                        request_output_queue_type,
-                        self.manager_args.create_migration_config(),
-                        backend_type,
-                        engine_args,
-                        self.manager_args.profiling_result_file_path)
-
-        return instance
 
     def init_instances(self,
                        request_output_queue_type: QueueType,
                        backend_type: BackendType,
+                       instance_args: InstanceArgs,
                        engine_args
                       ) -> Tuple[List[str], List[Llumlet]]:
         instance_ids: List[str] = []
         instances: List[Llumlet] = []
         for _ in range(self.manager_args.initial_instances):
             instance_id = random_uuid()
-            placement_group = self._init_placement_group(get_placement_group_name(instance_id), engine_args, backend_type)
-            instance = self._init_instance(instance_id, placement_group, request_output_queue_type, backend_type, engine_args)
+            placement_group = self.launcher.init_placement_group(get_placement_group_name(instance_id), engine_args, backend_type)
+            instance = self.launcher.init_instance(instance_id, instance_args, placement_group, request_output_queue_type,
+                                           backend_type, engine_args)
             instance_ids.append(instance_id)
             instances.append(instance)
 
-        self.scale_up(instance_ids, instances)
+        self.scale_up(instance_ids, instances, [instance_args]*len(instance_ids))
 
         return instance_ids, instances
 
-    def _init_server_and_instance(self,
-                                  instance_id: str,
-                                  placement_group: PlacementGroup):
-        async def done_scale_up():
+    def _inner_check_pd_deployment(self) -> str:
+        prefill_instance_ids = self.global_scheduler.dispatch_scheduler.available_dispatch_instance_set
+        cur_num_prefill = len(prefill_instance_ids)
+        decode_instance_ids = self.global_scheduler.instance_id_set - prefill_instance_ids
+        cur_num_decode = len(decode_instance_ids)
+
+        scale_down_instance_id = ""
+        if cur_num_prefill == 0 and cur_num_decode > 0:
+            scale_down_instance_id = random.choice(list(decode_instance_ids))
+            logger.info("[_inner_check_pd_deployment] pd_ratio: {}, cur_num_prefill: {}, cur_num_decode: {}, "
+                        "all decode, scale down decode instance {}".format(self.manager_args.pd_ratio,
+                        cur_num_prefill, cur_num_decode, scale_down_instance_id))
+
+        if cur_num_decode == 0 and cur_num_prefill > 0:
+            scale_down_instance_id = random.choice(list(prefill_instance_ids))
+            logger.info("[_inner_check_pd_deployment] pd_ratio: {}, cur_num_prefill: {}, cur_num_decode: {}, "
+                        "all prefill, scale down prefill instance {}".format(self.manager_args.pd_ratio,
+                        cur_num_prefill, cur_num_decode, scale_down_instance_id))
+
+        if scale_down_instance_id:
+            self.scale_down(scale_down_instance_id)
+
+        return scale_down_instance_id
+
+    # TODO(KuilongCui): currently, only one naive state check policy is implemented, which prevents the
+    # cluster from consisting entirely of prefill or decode instances.
+    async def _check_pd_deployment_states_loop(self, interval: float) -> None:
+        previous_penging_pg_names = None
+
+        while True:
             try:
-                manager = ray.get_actor(get_manager_name(), namespace="llumnix")
-                await instance.is_ready.remote()
-                await server.run.remote(manager, instance_id, instance)
-                self.scale_up(instance_id, instance)
+                pending_pg_states = list_placement_groups(filters=[("state", "=", "PENDING")])
+                rescheduling_pg_states = list_placement_groups(filters=[("state", "=", "RESCHEDULING")])
+                all_penging_pg_names = [pg.name for pg in pending_pg_states]
+
+                if previous_penging_pg_names and len(rescheduling_pg_states) == 0 :
+                    new_pending_pg_states = list_placement_groups(filters=[("state", "=", "PENDING")])
+                    all_new_penging_pg_names = [pg.name for pg in new_pending_pg_states]
+                    if len(set(previous_penging_pg_names).difference(set(all_new_penging_pg_names))) == 0:
+                        self._inner_check_pd_deployment()
+                    previous_penging_pg_names = all_new_penging_pg_names
+                else:
+                    previous_penging_pg_names = all_penging_pg_names
+
+                await asyncio.sleep(interval)
             # pylint: disable=broad-except
             except Exception as e:
                 logger.error("Unexpected exception: {}".format(e))
                 logger.error("Exception traceback: {}".format(traceback.format_exc()))
-                self._clear_instance_ray_resources(instance_id)
-
-        request_output_queue_type = QueueType(self.entrypoints_args.request_output_queue_type)
-        instance = self._init_instance(instance_id, placement_group, request_output_queue_type, self.backend_type, self.engine_args)
-        server = self._init_server(get_server_name(instance_id), placement_group, self.entrypoints_args)
-        asyncio.create_task(done_scale_up())
 
     async def _check_deployment_states_loop(self, interval: float) -> None:
         async def watch_instance_deployment_states(instance_id: str):
@@ -623,7 +600,7 @@ class Manager:
                 wait_pending_instance_time += WATCH_DEPLOYMENT_INTERVAL
                 if wait_pending_instance_time >= WATCH_DEPLOYMENT_INTERVAL_PENDING_INSTANCE:
                     break
-            pg_created, server_alive, instance_alive = self._get_instance_deployment_states(instance_id)
+            pg_created, server_alive, instance_alive = self.launcher.get_instance_deployment_states(instance_id)
             if pg_created and (not server_alive or not instance_alive):
                 logger.warning("Instance {} deployment states incorrect, states: (pg {}, server {}, instance {})"
                                .format(instance_id, pg_created, server_alive, instance_alive))
@@ -631,7 +608,7 @@ class Manager:
 
         while True:
             try:
-                curr_pgs, curr_servers, curr_instances = self._get_cluster_deployment()
+                curr_pgs, curr_servers, curr_instances = self.launcher.get_cluster_deployment()
                 assert len(curr_pgs) >= max(len(curr_servers), len(curr_instances))
                 tasks = []
                 for instance_id in curr_pgs:
@@ -669,37 +646,6 @@ class Manager:
         await asyncio.gather(*tasks, return_exceptions=True)
 
         return results
-
-    def _get_cluster_deployment(self) -> Tuple[Dict[str, PlacementGroup], Dict[str, APIServerActor], Dict[str, Llumlet]]:
-        curr_pgs: Dict[str, PlacementGroup] = {}
-        curr_servers: Dict[str, PlacementGroup] = {}
-        curr_instances: Dict[str, Llumlet] = {}
-
-        created_pg_states = list_placement_groups(filters=[("state", "=", "CREATED")])
-        for created_pg_state in created_pg_states:
-            instance_id = created_pg_state["name"].split("_")[-1]
-            curr_pgs[instance_id] = ray.util.get_placement_group(created_pg_state["name"])
-
-        alive_actor_states = list_actors(filters=[("state", "=", "ALIVE")])
-        for alive_actor_state in alive_actor_states:
-            if alive_actor_state["name"].startswith(SERVER_NAME_PREFIX):
-                instance_id = alive_actor_state["name"].split("_")[-1]
-                curr_servers[instance_id] = ray.get_actor(alive_actor_state["name"], namespace="llumnix")
-            elif alive_actor_state["name"].startswith(INSTANCE_NAME_PREFIX):
-                instance_id = alive_actor_state["name"].split("_")[-1]
-                curr_instances[instance_id] = ray.get_actor(alive_actor_state["name"], namespace="llumnix")
-
-        return curr_pgs, curr_servers, curr_instances
-
-    def _get_instance_deployment_states(self, instance_id: str):
-        pg_state = list_placement_groups(filters=[("name", "=", get_placement_group_name(instance_id))])
-        pg_created = len(pg_state) == 1 and pg_state[0]["state"] == "CREATED"
-        server_state = list_actors(filters=[("name", "=", get_server_name(instance_id))])
-        server_alive = len(server_state) == 1 and server_state[0]["state"] == "ALIVE"
-        instance_state = list_actors(filters=[("name", "=", get_instance_name(instance_id))])
-        instance_alive = len(instance_state) == 1 and instance_state[0]["state"] == "ALIVE"
-
-        return pg_created, server_alive, instance_alive
 
     async def _get_request_instance(self) -> None:
         def get_request_instance_done_callback(instance_id: str, fut):
@@ -742,8 +688,8 @@ class Manager:
             'step_id',
             'gpu_cache_usage',
             'num_available_gpu_blocks',
-            'instance_load',
-            'max_tot_tokens',
+            'dispatch_load_metric',
+            'migration_load_metric',
             'num_running_requests',
             'num_waiting_requests',
             'num_killed_requests',
@@ -770,8 +716,8 @@ class Manager:
                     instance_info.step_id,
                     instance_info.gpu_cache_usage,
                     instance_info.num_available_gpu_blocks,
-                    instance_info.instance_load_migrate,
-                    instance_info.max_tot_tokens,
+                    instance_info.dispatch_load_metric,
+                    instance_info.migration_load_metric,
                     instance_info.num_running_requests,
                     instance_info.num_waiting_requests,
                     instance_info.num_killed_requests,

--- a/llumnix/utils.py
+++ b/llumnix/utils.py
@@ -99,7 +99,8 @@ def clear_gloo_backend_state():
     try:
         # clear gloo migrate backend intermediate state
         ray.kill(ray.get_actor("gloo_queue", "llumnix"))
-    except ValueError:
+    # pylint: disable=broad-except
+    except Exception:
         # gloo_queue may not have been created yet; just ignore this error.
         pass
 

--- a/tests/e2e_test/utils.py
+++ b/tests/e2e_test/utils.py
@@ -29,7 +29,9 @@ def generate_launch_command(result_filename: str = "",
                             max_model_len: int = 4096,
                             log_instance_info: bool = False,
                             request_migration_policy: str = 'SR',
-                            max_num_batched_tokens: int = 16000):
+                            max_num_batched_tokens: int = 16000,
+                            enable_pd_disagg: bool = False,
+                            instance_type: str = "no_constraints"):
     command = (
         f"RAY_DEDUP_LOGS=0 HEAD_NODE_IP={HEAD_NODE_IP} HEAD_NODE=1 "
         f"nohup python -u -m llumnix.entrypoints.vllm.api_server "
@@ -50,6 +52,8 @@ def generate_launch_command(result_filename: str = "",
         f"--tensor-parallel-size 1 "
         f"--request-output-queue-port {1234+port} "
         f"{'--launch-ray-cluster ' if launch_ray_cluster else ''}"
+        f"{'--enable-pd-disagg ' if enable_pd_disagg else ''}"
+        f"--instance-type {instance_type} "
         f"--max-num-batched-tokens {max_num_batched_tokens} "
         f"{'> instance_'+result_filename if len(result_filename)> 0 else ''} 2>&1 &"
     )
@@ -64,7 +68,9 @@ def generate_serve_command(result_filename: str = "",
                            max_model_len: int = 4096,
                            log_instance_info: bool = False,
                            request_migration_policy: str = 'SR',
-                           max_num_batched_tokens: int = 16000):
+                           max_num_batched_tokens: int = 16000,
+                           enable_pd_disagg: bool = False,
+                           pd_ratio: str = "1:1"):
     command = (
         f"RAY_DEDUP_LOGS=0 "
         f"nohup python -u -m llumnix.entrypoints.vllm.serve "
@@ -84,7 +90,9 @@ def generate_serve_command(result_filename: str = "",
         f"--tensor-parallel-size 1 "
         f"--request-output-queue-port {1234+port} "
         f"--max-num-batched-tokens {max_num_batched_tokens} "
+        f"--pd-ratio {pd_ratio} "
         f"--enable-port-increment "
+        f"{'--enable-pd-disagg ' if enable_pd_disagg else ''}"
         f"{'> instance_'+result_filename if len(result_filename)> 0 else ''} 2>&1 &"
     )
     return command

--- a/tests/unit_test/backends/vllm/test_migration_backend.py
+++ b/tests/unit_test/backends/vllm/test_migration_backend.py
@@ -19,7 +19,7 @@ import ray
 from vllm.engine.arg_utils import EngineArgs
 
 from llumnix.backends.vllm.worker import MigrationWorker
-from llumnix.arg_utils import ManagerArgs
+from llumnix.arg_utils import InstanceArgs
 from llumnix.utils import random_uuid, initialize_placement_group, get_placement_group_name
 
 # pylint: disable=unused-import
@@ -41,7 +41,7 @@ class MockMigrationWorker(MigrationWorker):
 @pytest.mark.parametrize("backend", ['rayrpc', 'gloo', 'nccl'])
 def test_migrate_cache(ray_env, backend):
     engine_config = EngineArgs(model='facebook/opt-125m', max_model_len=8, enforce_eager=True).create_engine_config()
-    migraiton_config = ManagerArgs(migration_buffer_blocks=3, migration_num_layers=5).create_migration_config()
+    migraiton_config = InstanceArgs(migration_buffer_blocks=3, migration_num_layers=5).create_migration_config()
     migraiton_config.migration_backend = backend
 
     worker0 = create_worker(rank=0, local_rank=0, engine_config=engine_config,

--- a/tests/unit_test/backends/vllm/test_worker.py
+++ b/tests/unit_test/backends/vllm/test_worker.py
@@ -21,7 +21,7 @@ from vllm.worker.cache_engine import CacheEngine
 from vllm.config import EngineConfig
 from vllm.executor.ray_gpu_executor import RayWorkerWrapper
 
-from llumnix.arg_utils import ManagerArgs
+from llumnix.arg_utils import InstanceArgs
 from llumnix.utils import random_uuid
 from llumnix.utils import initialize_placement_group, get_placement_group_name
 
@@ -59,7 +59,7 @@ def create_worker(rank: int, local_rank: int, engine_config: EngineConfig,
 @pytest.mark.parametrize("backend", ['rayrpc', 'gloo', 'nccl'])
 def test_reserve_memory_for_migration(ray_env, backend):
     engine_config = EngineArgs(model='facebook/opt-125m', max_model_len=8, enforce_eager=True).create_engine_config()
-    migration_config = ManagerArgs(migration_buffer_blocks=1).create_migration_config()
+    migration_config = InstanceArgs(migration_buffer_blocks=1).create_migration_config()
     migration_config.migration_backend = backend
     worker = create_worker(rank=0, local_rank=0, engine_config=engine_config)
     ray.get(worker.execute_method.remote('init_device'))
@@ -80,7 +80,7 @@ def test_reserve_memory_for_migration(ray_env, backend):
 @pytest.mark.parametrize("backend", ['rayrpc', 'gloo', 'nccl'])
 def test_rebuild_migration_backend(ray_env, backend):
     engine_config = EngineArgs(model='facebook/opt-125m', max_model_len=8, enforce_eager=True).create_engine_config()
-    migration_config = ManagerArgs(migration_buffer_blocks=1).create_migration_config()
+    migration_config = InstanceArgs(migration_buffer_blocks=1).create_migration_config()
     migration_config.migration_backend = backend
 
     worker0 = create_worker(rank=0, local_rank=0, engine_config=engine_config)

--- a/tests/unit_test/entrypoints/test_utils.py
+++ b/tests/unit_test/entrypoints/test_utils.py
@@ -33,8 +33,7 @@ def test_launch_ray_cluster():
     assert result.returncode == 0
 
 def test_init_manager(ray_env):
-    manager_args = ManagerArgs()
-    manager = init_manager(manager_args)
+    manager = init_manager(ManagerArgs())
     assert manager is not None
     manager_actor_handle = ray.get_actor(get_manager_name(), namespace='llumnix')
     assert manager_actor_handle is not None
@@ -47,14 +46,12 @@ def test_init_zmq(ray_env):
     assert request_output_queue is not None
 
 def test_retry_manager_method_sync(ray_env):
-    manager_args = ManagerArgs()
-    manager = init_manager(manager_args)
+    manager = init_manager(ManagerArgs())
     ret = retry_manager_method_sync(manager.is_ready.remote, 'is_ready')
     assert ret is True
 
 @pytest.mark.asyncio
 async def test_retry_manager_method_async(ray_env):
-    manager_args = ManagerArgs()
-    manager = init_manager(manager_args)
+    manager = init_manager(ManagerArgs())
     ret = await retry_manager_method_async(manager.is_ready.remote, 'is_ready')
     assert ret is True

--- a/tests/unit_test/global_scheduler/test_dispatch_scheduler.py
+++ b/tests/unit_test/global_scheduler/test_dispatch_scheduler.py
@@ -11,56 +11,73 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import defaultdict
 import random
-import pytest
 
-from llumnix.instance_info import InstanceLoadCalculator, InstanceInfo
+from llumnix.instance_info import InstanceInfo
 from llumnix.global_scheduler.dispatch_scheduler import DispatchScheduler
+from llumnix.arg_utils import InstanceArgs
 
 INSTANCE_NUM = 4
 
-def init_dispatch_scheduler(policy='load'):
-    instance_load_calculator = InstanceLoadCalculator('remaining_steps', True)
-    dispatch_scheduler = DispatchScheduler(policy, instance_load_calculator, 2)
-    return dispatch_scheduler
+def test_add_instance_and_remove_instance():
+    dispatch_scheduler = DispatchScheduler('balanced')
 
-@pytest.fixture
-def dispatch_scheduler():
-    dispatch_scheduler = init_dispatch_scheduler()
-    yield dispatch_scheduler
-
-@pytest.mark.parametrize("num_dispatch_instances", [1, 2, 3])
-def test_add_instance_and_remove_instance(dispatch_scheduler, num_dispatch_instances):
-    dispatch_scheduler.num_dispatch_instances = num_dispatch_instances
-    dispatch_scheduler.add_instance('instance_1')
-    assert dispatch_scheduler.num_instances == 1
+    dispatch_scheduler.add_instance('instance_1', InstanceArgs(instance_type="no_constraints"))
     assert len(dispatch_scheduler.available_dispatch_instance_set) == 1
     dispatch_scheduler.remove_instance('instance_1')
-    assert dispatch_scheduler.num_instances == 0
     assert len(dispatch_scheduler.available_dispatch_instance_set) == 0
 
-    dispatch_scheduler.add_instance('instance_2')
-    assert dispatch_scheduler.num_instances == 1
+    dispatch_scheduler.add_instance('instance_2', InstanceArgs(instance_type="no_constraints"))
     assert len(dispatch_scheduler.available_dispatch_instance_set) == 1
-    dispatch_scheduler.add_instance('instance_3')
-    assert dispatch_scheduler.num_instances == 2
-    assert len(dispatch_scheduler.available_dispatch_instance_set) == min(2, dispatch_scheduler.num_dispatch_instances)
+    dispatch_scheduler.add_instance('instance_3', InstanceArgs(instance_type="no_constraints"))
+    assert len(dispatch_scheduler.available_dispatch_instance_set) == 2
 
     dispatch_scheduler.remove_instance('instance_2')
-    assert dispatch_scheduler.num_instances == 1
     assert len(dispatch_scheduler.available_dispatch_instance_set) == 1
     dispatch_scheduler.remove_instance('instance_3')
-    assert dispatch_scheduler.num_instances == 0
+    assert len(dispatch_scheduler.available_dispatch_instance_set) == 0
+
+def test_dispatch_to_no_constraints_and_prefill():
+    dispatch_scheduler = DispatchScheduler('rr')
+    instance_num_requests = {}
+    instance_info_dict = {}
+    for instance_id in [f'instance_{i}' for i in range(INSTANCE_NUM)]:
+        instance_info = InstanceInfo(
+            instance_id=instance_id,
+            dispatch_load_metric=random.randint(1, 10),
+        )
+        instance_info_dict[instance_id] = instance_info
+    dispatch_scheduler.instance_num_requests = instance_num_requests
+    dispatch_scheduler.instance_info = instance_info_dict
+
+    dispatched_instance_ids = []
+    available_instance_type = ['no_constraints', 'prefill', 'decode']
+    for instance_id, _ in dispatch_scheduler.instance_info.items():
+        instance_type = random.choice(available_instance_type)
+        dispatch_scheduler.add_instance(instance_id, InstanceArgs(instance_type=instance_type))
+        if instance_type != 'decode':
+            dispatched_instance_ids.append(instance_id)
+        else:
+            assert instance_id not in dispatch_scheduler.available_dispatch_instance_set
+
+    instance_dispatch_info = defaultdict(int)
+    for _ in range(INSTANCE_NUM * 2):
+        instance_id = dispatch_scheduler.dispatch()
+        instance_dispatch_info[instance_id] += 1
+
+    for instance_id, num_requests in instance_dispatch_info.items():
+        assert instance_id in dispatched_instance_ids
+        assert num_requests >= 2
 
 def test_dispatch_balanced():
     num_tests = 100
     for _ in range(num_tests):
-        dispatch_scheduler = init_dispatch_scheduler('balanced')
+        dispatch_scheduler = DispatchScheduler('balanced')
         instance_num_requests = {}
         for instance_id in [f'instance_{i}' for i in range(1, INSTANCE_NUM + 1)]:
-            if len(dispatch_scheduler.available_dispatch_instance_set) < dispatch_scheduler.num_dispatch_instances:
-                dispatch_scheduler.available_dispatch_instance_set.add(instance_id)
-                instance_num_requests[instance_id] = random.randint(1, 10)
+            dispatch_scheduler.available_dispatch_instance_set.add(instance_id)
+            instance_num_requests[instance_id] = random.randint(1, 10)
         dispatch_scheduler.instance_num_requests = instance_num_requests
         min_instance_id = next(key for key, value in sorted(instance_num_requests.items(), key=lambda item: item[1]))
         instance_id = dispatch_scheduler.dispatch()
@@ -69,31 +86,29 @@ def test_dispatch_balanced():
 def test_dispatch_load():
     num_tests = 100
     for _ in range(num_tests):
-        dispatch_scheduler = init_dispatch_scheduler('load')
+        dispatch_scheduler = DispatchScheduler('load')
         instance_num_requests = {}
         instance_info_dict = {}
         for instance_id in [f'instance_{i}' for i in range(1, INSTANCE_NUM + 1)]:
             instance_info = InstanceInfo()
             instance_info.instance_id = instance_id
-            instance_info.instance_load_dispatch_scale = random.random()
+            instance_info.dispatch_load_metric = random.random()
             instance_info_dict[instance_id] = instance_info
-            if dispatch_scheduler.num_dispatch_instances <= 0 or (dispatch_scheduler.num_dispatch_instances > 0
-                and len(dispatch_scheduler.available_dispatch_instance_set) < dispatch_scheduler.num_dispatch_instances):
-                dispatch_scheduler.available_dispatch_instance_set.add(instance_id)
-                instance_num_requests[instance_id] = 0
+            dispatch_scheduler.available_dispatch_instance_set.add(instance_id)
+            instance_num_requests[instance_id] = 0
         dispatch_scheduler.instance_num_requests = instance_num_requests
         dispatch_scheduler.instance_info = instance_info_dict
         available_instance_dict = {key: value for key, value in instance_info_dict.items()
                                    if key in dispatch_scheduler.available_dispatch_instance_set}
         min_instance_id = next(key for key, value in sorted(available_instance_dict.items(),
-                                                            key=lambda item: item[1].instance_load_dispatch_scale))
+                                                            key=lambda item: item[1].dispatch_load_metric))
         instance_id = dispatch_scheduler.dispatch()
         assert min_instance_id == instance_id
 
 def test_dispatch_queue():
     num_tests = 100
     for _ in range(num_tests):
-        dispatch_scheduler = init_dispatch_scheduler('queue')
+        dispatch_scheduler = DispatchScheduler('queue')
         instance_num_requests = {}
         instance_info_dict = {}
         for instance_id in [f'instance_{i}' for i in range(1, INSTANCE_NUM + 1)]:
@@ -101,9 +116,8 @@ def test_dispatch_queue():
             instance_info.instance_id = instance_id
             instance_info.num_waiting_requests = random.randint(1, 10)
             instance_info_dict[instance_id] = instance_info
-            if len(dispatch_scheduler.available_dispatch_instance_set) < dispatch_scheduler.num_dispatch_instances:
-                dispatch_scheduler.available_dispatch_instance_set.add(instance_id)
-                instance_num_requests[instance_id] = 0
+            dispatch_scheduler.available_dispatch_instance_set.add(instance_id)
+            instance_num_requests[instance_id] = 0
         dispatch_scheduler.instance_num_requests = instance_num_requests
         dispatch_scheduler.instance_info = instance_info_dict
         available_instance_dict = {key: value for key, value in instance_info_dict.items()
@@ -115,8 +129,7 @@ def test_dispatch_queue():
 
 def test_dispatch_rr():
     instance_num = 7
-    instance_load_calculator = InstanceLoadCalculator('remaining_steps', True)
-    dispatch_scheduler = DispatchScheduler('rr', instance_load_calculator, 3)
+    dispatch_scheduler = DispatchScheduler("rr")
     instance_num_requests = {}
     instance_info_dict = {}
 
@@ -125,23 +138,13 @@ def test_dispatch_rr():
         instance_info.instance_id = instance_id
         instance_info.num_waiting_requests = random.randint(1, 10)
         instance_info_dict[instance_id] = instance_info
-        if  len(dispatch_scheduler.available_dispatch_instance_set) < dispatch_scheduler.num_dispatch_instances:
-            dispatch_scheduler.available_dispatch_instance_set.add(instance_id)
-            instance_num_requests[instance_id] = 0
+        dispatch_scheduler.available_dispatch_instance_set.add(instance_id)
+        instance_num_requests[instance_id] = 0
     dispatch_scheduler.instance_num_requests = instance_num_requests
     dispatch_scheduler.instance_info = instance_info_dict
 
-    num_request = 2 * instance_num + 2
+    num_request = 2 * instance_num + 1
     for idx in range(0, num_request):
         instance_id = dispatch_scheduler.dispatch()
-        target_instance_id = idx%dispatch_scheduler.num_dispatch_instances
+        target_instance_id = idx%instance_num
         assert instance_id == f'instance_{target_instance_id}'
-
-    for idx in range(instance_num):
-        if idx < dispatch_scheduler.num_dispatch_instances:
-            dispatch_scheduler.instance_num_requests[f'instance_{idx}'] = \
-                num_request // dispatch_scheduler.num_dispatch_instances + (1 \
-                    if num_request % dispatch_scheduler.num_dispatch_instances > \
-                        idx % dispatch_scheduler.num_dispatch_instances else 0)
-        else:
-            dispatch_scheduler.instance_num_requests[f'instance_{idx}'] = 0

--- a/tests/unit_test/global_scheduler/test_global_scheduler.py
+++ b/tests/unit_test/global_scheduler/test_global_scheduler.py
@@ -16,16 +16,16 @@ import pytest
 
 from llumnix.internal_config import GlobalSchedulerConfig
 from llumnix.global_scheduler.global_scheduler import GlobalScheduler
-from llumnix.instance_info import InstanceInfo
+from llumnix.instance_info import InstanceInfo, InstanceLoadCalculator
 from llumnix.utils import random_uuid
+from llumnix.arg_utils import InstanceArgs
 
 from .test_manager import get_instance_info_migrate_in, get_instance_info_migrate_out
 
 
 def init_global_scheduler():
-    global_scheduler_config = GlobalSchedulerConfig(0, 'remaining_steps', 'load', math.inf,
-                                                    'defrag_constrained', 3.0, True, 'avg_load',
-                                                    10, 60, False, 'rayrpc')
+    global_scheduler_config = GlobalSchedulerConfig(0, 'load', 'defrag_constrained', 3.0,
+                                                    'avg_load', 'remaining_steps', 10, 60, False, False)
     global_scheduler = GlobalScheduler(global_scheduler_config)
     return global_scheduler
 
@@ -47,7 +47,7 @@ def test_scale_up_and_scale_down(global_scheduler):
     initial_instances = 4
     instance_infos = init_instance_infos(initial_instances)
     instance_ids = [instance_info.instance_id for instance_info in instance_infos]
-    num_instances = global_scheduler.scale_up(instance_ids)
+    num_instances = global_scheduler.scale_up(instance_ids, [InstanceArgs(instance_type="no_constraints")]*len(instance_ids))
     assert num_instances == initial_instances
     instance_infos = init_instance_infos(initial_instances)
     instance_ids_1 = [instance_info.instance_id for instance_info in instance_infos]
@@ -62,7 +62,7 @@ def test_update_instance_infos(global_scheduler):
     global_scheduler.update_instance_infos(instance_infos)
     assert len(global_scheduler.instance_info) == 0
     instance_ids = [instance_info.instance_id for instance_info in instance_infos]
-    global_scheduler.scale_up(instance_ids)
+    global_scheduler.scale_up(instance_ids, [InstanceArgs(instance_type="no_constraints")]*len(instance_ids))
     global_scheduler.update_instance_infos(instance_infos)
     assert len(global_scheduler.instance_info) == initial_instances
 
@@ -70,7 +70,7 @@ def test_dispatch(global_scheduler):
     initial_instances = 4
     instance_infos = init_instance_infos(initial_instances)
     instance_ids = [instance_info.instance_id for instance_info in instance_infos]
-    global_scheduler.scale_up(instance_ids)
+    global_scheduler.scale_up(instance_ids, [InstanceArgs(instance_type="no_constraints")]*len(instance_ids))
     global_scheduler.update_instance_infos(instance_infos)
     instance_id, request_expected_steps = global_scheduler.dispatch()
     assert instance_id in instance_ids
@@ -82,9 +82,16 @@ def test_pair_migration(global_scheduler):
     instance_ids = [instance_id, instance_id_1]
     instance_info_migrate_in = get_instance_info_migrate_in(instance_id)
     instance_info_migrate_out = get_instance_info_migrate_out(instance_id_1)
+    instance_load_calculator = InstanceLoadCalculator("remaining_steps", "remaining_steps", False)
+    instance_load_calculator.compute_instance_load(instance_info_migrate_in)
+    instance_load_calculator.compute_instance_load(instance_info_migrate_out)
+    print("-------", instance_info_migrate_in.migration_load_metric)
+    print(instance_info_migrate_out.migration_load_metric)
     instance_infos = [instance_info_migrate_in, instance_info_migrate_out]
-    global_scheduler.scale_up(instance_ids)
+    global_scheduler.scale_up(instance_ids, [InstanceArgs(instance_type="no_constraints")]*len(instance_ids))
     global_scheduler.update_instance_infos(instance_infos)
+
     migrate_instace_pairs = global_scheduler.pair_migration("NO_CONSTRAINTS")
+    assert len(migrate_instace_pairs) > 0
     assert migrate_instace_pairs[0][0] == instance_id_1
     assert migrate_instace_pairs[0][1] == instance_id

--- a/tests/unit_test/global_scheduler/test_manager.py
+++ b/tests/unit_test/global_scheduler/test_manager.py
@@ -397,7 +397,7 @@ async def test_init_server_and_get_instance_deployment_states_and_instance_and_c
 @pytest.mark.parametrize("request_output_queue_type", ['rayqueue', 'zmq'])
 async def test_auto_scale_up_loop_and_get_cluster_deployment(ray_env, request_output_queue_type):
     manager, _, _, _, _ = init_manager_with_launch_mode(LaunchMode.GLOBAL, request_output_queue_type)
-    await asyncio.sleep(30.0)
+    await asyncio.sleep(60.0)
 
     num_instances = manager.scale_up([], [], [])
     assert num_instances == 4
@@ -410,7 +410,7 @@ async def test_auto_scale_up_loop_and_get_cluster_deployment(ray_env, request_ou
     assert len(instance_ids) == 4
     await manager.clear_instance_ray_resources(instance_ids[0])
     await manager.clear_instance_ray_resources(instance_ids[1])
-    await asyncio.sleep(30.0)
+    await asyncio.sleep(60.0)
 
     num_instances = manager.scale_up([], [], [])
     assert num_instances == 4
@@ -421,7 +421,7 @@ async def test_auto_scale_up_loop_and_get_cluster_deployment(ray_env, request_ou
 @pytest.mark.parametrize("request_output_queue_type", ['rayqueue', 'zmq'])
 async def test_check_deployment_states_loop_and_auto_scale_up_loop(ray_env, request_output_queue_type):
     manager, _, _, _, _ = init_manager_with_launch_mode(LaunchMode.GLOBAL, request_output_queue_type)
-    await asyncio.sleep(30.0)
+    await asyncio.sleep(60.0)
 
     num_instances = manager.scale_up([], [], [])
     assert num_instances == 4
@@ -466,7 +466,7 @@ def test_pd_disagg_gloal_launch_instance_type():
 async def test_pd_disagg_gloal_launch_deployment_and_auto_scale_up_loop(ray_env, request_output_queue_type):
     manager, _, _, _, _ = init_manager_with_launch_mode(LaunchMode.GLOBAL, request_output_queue_type,
                                                         enable_pd_disagg=True, pd_ratio="1:1")
-    await asyncio.sleep(30.0)
+    await asyncio.sleep(60.0)
 
     num_instances = manager.scale_up([], [], [])
     assert num_instances == 4

--- a/tests/unit_test/global_scheduler/test_manager.py
+++ b/tests/unit_test/global_scheduler/test_manager.py
@@ -11,20 +11,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+import os
 import time
 import math
 import ray
 import pytest
 import numpy as np
 
+import torch
 from vllm import EngineArgs
 
-from llumnix.arg_utils import ManagerArgs, EntrypointsArgs, LaunchArgs
+from llumnix.launcher import Launcher
+from llumnix.arg_utils import ManagerArgs, EntrypointsArgs, LaunchArgs, InstanceArgs
 from llumnix.manager import Manager
-from llumnix.instance_info import InstanceInfo
+from llumnix.instance_info import InstanceInfo, InstanceLoadCalculator
 from llumnix.server_info import ServerInfo
 from llumnix.queue.queue_type import QueueType
-from llumnix.global_scheduler.scaling_scheduler import InstanceType
+from llumnix.instance_info import InstanceType
 from llumnix.backends.vllm.simulator import BackendSimVLLM
 from llumnix.backends.backend_interface import BackendType
 from llumnix.backends.profiling import LatencyMemData
@@ -59,6 +63,9 @@ class MockLlumlet:
 
     def is_ready(self) -> bool:
         return True
+
+    def get_instance_args(self) -> InstanceArgs:
+        return InstanceArgs()
 
     def get_all_request_ids(self):
         return list(self.request_id_set)
@@ -108,24 +115,53 @@ class MockBackendSim(BackendSimVLLM):
 
 def init_manager():
     try:
-        manager_args = ManagerArgs(migration_backend="rayrpc", enable_migration=True)
+        manager_args = ManagerArgs(enable_migration=True)
         manager_args.log_instance_info = False
-        manager = Manager.from_args(manager_args=manager_args)
+        manager = Manager.from_args(
+            entrypoints_args=None,
+            manager_args=manager_args,
+            instance_args=InstanceArgs(migration_backend="rayrpc"),
+            engine_args=None,
+            launch_args=None,
+        )
     except ValueError:
         manager = ray.get_actor(get_manager_name(), namespace='llumnix')
     ray.get(manager.is_ready.remote())
     return manager
 
-def init_manager_with_launch_mode(launch_mode, request_output_queue_type="rayqueue"):
-    manager_args = ManagerArgs(migration_backend="rayrpc", enable_port_increment=True)
+class MockManager(Manager):
+    async def init_placement_group(self, *args, **kwargs):
+        return self.launcher.init_placement_group(*args, **kwargs)
+
+    async def init_server_and_instance(self, *args, **kwargs):
+        return self.launcher.init_server_and_instance(*args, **kwargs)
+
+    async def clear_instance_ray_resources(self, instance_id: str):
+        return self.launcher.clear_instance_ray_resources(instance_id)
+
+    async def get_cluster_deployment(self):
+        return self.launcher.get_cluster_deployment()
+
+    async def get_instance_deployment_states(self, instance_id: str):
+        return self.launcher.get_instance_deployment_states(instance_id)
+
+def init_manager_with_launch_mode(launch_mode, request_output_queue_type="rayqueue",
+                                  enable_pd_disagg=False, pd_ratio="1:3"):
+    manager_args = ManagerArgs(enable_port_increment=True, enable_port_offset_store=True,
+                               enable_pd_disagg=enable_pd_disagg, pd_ratio=pd_ratio)
+    instance_args = InstanceArgs(migration_backend="rayrpc")
     entrypoints_args = EntrypointsArgs(host="127.0.0.1", port=8000, request_output_queue_type=request_output_queue_type)
     engine_args = EngineArgs(model="facebook/opt-125m", worker_use_ray=True)
     launch_args = LaunchArgs(launch_mode=launch_mode, backend_type=BackendType.VLLM)
-    manager = Manager.from_args(manager_args=manager_args,
-                                entrypoints_args=entrypoints_args,
-                                engine_args=engine_args,
-                                launch_args=launch_args)
-    ray.get(manager.is_ready.remote())
+
+    # As mock_manager can not be initialized to ray actor, it is initialized as local variable.
+    # But, some place need to get the manager actor, so create the dummy manager actor here.
+    dummy_manager_actor = init_manager()
+    ray.get(dummy_manager_actor.is_ready.remote())
+    manager = MockManager(entrypoints_args=entrypoints_args, manager_args=manager_args,
+                      instance_args=instance_args, engine_args=engine_args,
+                      launch_args=launch_args, work_dir=os.getcwd())
+
     return manager, manager_args, entrypoints_args, engine_args, launch_args
 
 def init_instances(initial_instances):
@@ -182,7 +218,7 @@ def test_init_llumlet(ray_env, llumlet):
 
 def test_init_instances(ray_env, manager):
     engine_args = EngineArgs(model="facebook/opt-125m", worker_use_ray=True)
-    _, instances = ray.get(manager.init_instances.remote(QueueType("rayqueue"), BackendType.VLLM, engine_args))
+    _, instances = ray.get(manager.init_instances.remote(QueueType("rayqueue"), BackendType.VLLM, InstanceArgs(), engine_args))
     num_instances = len(instances)
     manager_args = ManagerArgs()
     assert num_instances == manager_args.initial_instances
@@ -193,7 +229,7 @@ def test_init_instances_sim(ray_env, manager):
     import llumnix.backends.vllm.simulator
     llumnix.backends.vllm.simulator.BackendSimVLLM = MockBackendSim
     engine_args = EngineArgs(model="facebook/opt-125m", worker_use_ray=True)
-    _, instances = ray.get(manager.init_instances.remote(QueueType("rayqueue"), BackendType.SIM_VLLM, engine_args))
+    _, instances = ray.get(manager.init_instances.remote(QueueType("rayqueue"), BackendType.SIM_VLLM, InstanceArgs(), engine_args))
     num_instances = len(instances)
     manager_args = ManagerArgs()
     assert num_instances == manager_args.initial_instances
@@ -201,12 +237,12 @@ def test_init_instances_sim(ray_env, manager):
 def test_scale_up_and_down(ray_env, manager):
     initial_instances = 4
     instance_ids, instances = init_instances(initial_instances)
-    num_instances = ray.get(manager.scale_up.remote(instance_ids, instances))
+    num_instances = ray.get(manager.scale_up.remote(instance_ids, instances, [InstanceArgs()]*initial_instances))
     assert num_instances == initial_instances
     instance_ids_1, instances_1 = init_instances(initial_instances)
     num_instances = ray.get(manager.scale_down.remote(instance_ids_1))
     assert num_instances == initial_instances
-    num_instances = ray.get(manager.scale_up.remote(instance_ids_1, instances_1))
+    num_instances = ray.get(manager.scale_up.remote(instance_ids_1, instances_1, [InstanceArgs()]*initial_instances))
     assert num_instances == initial_instances * 2
     num_instances = ray.get(manager.scale_down.remote(instance_ids))
     assert num_instances == initial_instances
@@ -219,14 +255,14 @@ def test_connect_to_instances(ray_env):
     ray.get([instance.is_ready.remote() for instance in instances])
     manager = init_manager()
     instance_ids_1, instances_1 = init_instances(initial_instances)
-    num_instances = ray.get(manager.scale_up.remote(instance_ids_1, instances_1))
+    num_instances = ray.get(manager.scale_up.remote(instance_ids_1, instances_1, [InstanceArgs()]*initial_instances))
     assert num_instances == initial_instances * 2
     num_instances = ray.get(manager.scale_down.remote(instance_ids))
     assert num_instances == initial_instances
 
 def test_generate_and_abort(ray_env, manager, llumlet):
     instance_id = ray.get(llumlet.get_instance_id.remote())
-    ray.get(manager.scale_up.remote(instance_id, llumlet))
+    ray.get(manager.scale_up.remote(instance_id, llumlet, InstanceArgs()))
     request_id = random_uuid()
     num_requests = ray.get(llumlet.get_num_requests.remote())
     assert num_requests == 0
@@ -263,21 +299,26 @@ def test_get_request_instance(ray_env):
     assert num_requests_1 == 0
 
 def get_instance_info_migrate_in(instance_id):
-    instance_info = InstanceInfo()
-    instance_info.instance_id = instance_id
-    instance_info.num_available_gpu_blocks = np.inf
-    instance_info.num_running_requests = 1
-    instance_info.num_blocks_first_waiting_request = 0
-    instance_info.instance_type = InstanceType.NO_CONSTRAINTS
+    instance_info = InstanceInfo(
+        instance_id=instance_id,
+        instance_type=InstanceType.NO_CONSTRAINTS,
+        num_available_gpu_blocks=np.inf,
+        num_running_requests=1,
+        num_blocks_first_waiting_request=0,
+        num_killed_requests=0
+    )
+
     return instance_info
 
 def get_instance_info_migrate_out(instance_id):
-    instance_info = InstanceInfo()
-    instance_info.instance_id = instance_id
-    instance_info.num_available_gpu_blocks = 0
-    instance_info.num_running_requests = 1
-    instance_info.num_blocks_first_waiting_request = np.inf
-    instance_info.instance_type = InstanceType.NO_CONSTRAINTS
+    instance_info = InstanceInfo(
+        instance_id=instance_id,
+        instance_type=InstanceType.NO_CONSTRAINTS,
+        num_available_gpu_blocks=0,
+        num_running_requests=1,
+        num_blocks_first_waiting_request=np.inf,
+        num_killed_requests=np.inf
+    )
     return instance_info
 
 def test_update_instance_info_loop_and_migrate(ray_env, manager):
@@ -288,58 +329,60 @@ def test_update_instance_info_loop_and_migrate(ray_env, manager):
         for _ in range(2*(i+1)):
             ray.get(instances[i].generate.remote(random_uuid(), None, math.inf, None, None))
 
-    instance_info = InstanceInfo()
-    instance_info.instance_type = InstanceType.NO_CONSTRAINTS
-
+    instance_load_calculator = InstanceLoadCalculator("remaining_steps", "remaining_steps", True)
     for i in range(num_instances):
-        instance_info.instance_id = instance_ids[i]
-        instance_info.num_available_gpu_blocks = 40 - i * 10
-        instance_info.num_running_requests = i
-        instance_info.num_blocks_first_waiting_request = i
+        instance_info = InstanceInfo(
+            instance_id=instance_ids[i],
+            instance_type=InstanceType.NO_CONSTRAINTS,
+            num_free_gpu_blocks=40-i*10,
+            num_running_requests=i+1,
+            num_blocks_first_waiting_request=i,
+        )
+        instance_load_calculator.compute_instance_load(instance_info)
         ray.get(instances[i].set_instance_info.remote(instance_info))
 
     for i in range(num_instances):
         num_migrate_out = ray.get(instances[i].get_num_migrate_out.remote())
         assert num_migrate_out == 0
 
-    ray.get(manager.scale_up.remote(instance_ids, instances))
-    time.sleep(2)
+    ray.get(manager.scale_up.remote(instance_ids, instances, [InstanceArgs()]*len(instance_ids)))
+    time.sleep(3)
 
     for i in range(num_instances):
         num_migrate_out = ray.get(instances[i].get_num_migrate_out.remote())
         num_migrate_in = ray.get(instances[i].get_num_migrate_in.remote())
-
         if i == 0:
             assert num_migrate_in > 1 and num_migrate_out == 0
         elif i == num_instances - 1:
             assert num_migrate_in == 0 and num_migrate_out > 1
-        else:
-            assert num_migrate_in == 0 and num_migrate_out == 0
 
-def test_init_server_and_get_instance_deployment_states_and_instance_and_clear_instance_ray_resources(ray_env):
+@pytest.mark.asyncio
+async def test_init_server_and_get_instance_deployment_states_and_instance_and_clear_instance_ray_resources(ray_env):
     manager, _, _, engine_args, _ = init_manager_with_launch_mode(LaunchMode.LOCAL)
     instance_id = random_uuid()
-    pg = ray.get(manager._init_placement_group.remote(get_placement_group_name(instance_id),
-                                                      engine_args, BackendType.VLLM, init_server=True))
+    pg = await manager.init_placement_group(get_placement_group_name(instance_id),
+                                                      engine_args, BackendType.VLLM, init_server=True)
     pg = ray.util.get_placement_group(get_placement_group_name(instance_id))
     ray.get(pg.ready())
-    ray.get(manager._init_server_and_instance.remote(instance_id, pg))
+    await manager.init_server_and_instance(instance_id, EntrypointsArgs(), InstanceArgs(), engine_args, BackendType.VLLM, pg)
+
     # wait for scale up
-    time.sleep(5.0)
+    await asyncio.sleep(5.0)
     server = ray.get_actor(get_server_name(instance_id), namespace="llumnix")
     ray.get(server.is_ready.remote())
     instance = ray.get_actor(get_instance_name(instance_id), namespace="llumnix")
     ray.get(instance.is_ready.remote())
-    num_instances = ray.get(manager.scale_up.remote(instance_id, instance))
+    num_instances = manager.scale_up(instance_id, instance, InstanceArgs())
     assert num_instances == 1
 
-    pg_created, server_alive, instance_alive = ray.get(manager._get_instance_deployment_states.remote(instance_id))
+    pg_created, server_alive, instance_alive = await manager.get_instance_deployment_states(instance_id)
     assert pg_created and server_alive and instance_alive
 
     # test clear_instance_ray_resources
-    ray.get(manager._clear_instance_ray_states.remote(instance_id))
+    await manager.clear_instance_ray_resources(instance_id)
     # wait for remove and kill
-    time.sleep(1.0)
+    await asyncio.sleep(5.0)
+
     pg_exists = is_placement_group_exists(get_placement_group_name(instance_id))
     assert not pg_exists
     server_exists = is_actor_exists(get_server_name(instance_id))
@@ -347,37 +390,42 @@ def test_init_server_and_get_instance_deployment_states_and_instance_and_clear_i
     instance_exists = is_actor_exists(get_instance_name(instance_id))
     assert not instance_exists
 
-    pg_created, server_alive, instance_alive = ray.get(manager._get_instance_deployment_states.remote(instance_id))
+    pg_created, server_alive, instance_alive = await manager.get_instance_deployment_states(instance_id)
     assert not pg_created and not server_alive and not instance_alive
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("request_output_queue_type", ['rayqueue', 'zmq'])
-def test_auto_scale_up_loop_and_get_cluster_deployment(ray_env, request_output_queue_type):
+async def test_auto_scale_up_loop_and_get_cluster_deployment(ray_env, request_output_queue_type):
     manager, _, _, _, _ = init_manager_with_launch_mode(LaunchMode.GLOBAL, request_output_queue_type)
-    time.sleep(60.0)
-    num_instances = ray.get(manager.scale_up.remote([], []))
+    await asyncio.sleep(30.0)
+
+    num_instances = manager.scale_up([], [], [])
     assert num_instances == 4
-    curr_pgs, curr_servers, curr_instances = ray.get(manager._get_cluster_deployment.remote())
+    curr_pgs, curr_servers, curr_instances = await manager.get_cluster_deployment()
     assert len(curr_pgs) == 4 and len(curr_servers) == 4 and len(curr_instances) == 4
 
     actor_names_dict = ray.util.list_named_actors(all_namespaces=True)
     instance_ids = [actor_name_dict['name'].split("_")[-1] for actor_name_dict in actor_names_dict
                     if actor_name_dict['name'].startswith(INSTANCE_NAME_PREFIX)]
     assert len(instance_ids) == 4
-    ray.get(manager._clear_instance_ray_states.remote(instance_ids[0]))
-    ray.get(manager._clear_instance_ray_states.remote(instance_ids[1]))
-    time.sleep(60.0)
-    num_instances = ray.get(manager.scale_up.remote([], []))
+    await manager.clear_instance_ray_resources(instance_ids[0])
+    await manager.clear_instance_ray_resources(instance_ids[1])
+    await asyncio.sleep(30.0)
+
+    num_instances = manager.scale_up([], [], [])
     assert num_instances == 4
-    curr_pgs, curr_servers, curr_instances = ray.get(manager._get_cluster_deployment.remote())
+    curr_pgs, curr_servers, curr_instances = await manager.get_cluster_deployment()
     assert len(curr_pgs) == 4 and len(curr_servers) == 4 and len(curr_instances) == 4
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("request_output_queue_type", ['rayqueue', 'zmq'])
-def test_check_deployment_states_loop_and_auto_scale_up_loop(ray_env, request_output_queue_type):
+async def test_check_deployment_states_loop_and_auto_scale_up_loop(ray_env, request_output_queue_type):
     manager, _, _, _, _ = init_manager_with_launch_mode(LaunchMode.GLOBAL, request_output_queue_type)
-    time.sleep(60.0)
-    num_instances = ray.get(manager.scale_up.remote([], []))
+    await asyncio.sleep(30.0)
+
+    num_instances = manager.scale_up([], [], [])
     assert num_instances == 4
-    curr_pgs, curr_servers, curr_instances = ray.get(manager._get_cluster_deployment.remote())
+    curr_pgs, curr_servers, curr_instances = await manager.get_cluster_deployment()
     assert len(curr_pgs) == 4 and len(curr_servers) == 4 and len(curr_instances) == 4
 
     actor_names_dict = ray.util.list_named_actors(all_namespaces=True)
@@ -388,8 +436,111 @@ def test_check_deployment_states_loop_and_auto_scale_up_loop(ray_env, request_ou
     kill_server(instance_ids[1])
     kill_instance(instance_ids[2])
     # Wait for check deployment states, scale down instance and auto scale up.
-    time.sleep(90.0)
-    num_instances = ray.get(manager.scale_up.remote([], []))
+    await asyncio.sleep(90.0)
+
+    num_instances = manager.scale_up([], [], [])
     assert num_instances == 4
-    curr_pgs, curr_servers, curr_instances = ray.get(manager._get_cluster_deployment.remote())
+    curr_pgs, curr_servers, curr_instances = await manager.get_cluster_deployment()
     assert len(curr_pgs) == 4 and len(curr_servers) == 4 and len(curr_instances) == 4
+
+def test_pd_disagg_gloal_launch_instance_type():
+    launcher = Launcher(None, True, False, True, False, [1, 2])
+
+    assert launcher._get_next_instance_type(0, 0, [1, 2]) == InstanceType.PREFILL
+    launcher.inflight_num_prefill += 1
+
+    assert launcher._get_next_instance_type(0, 0, [1, 2]) == InstanceType.DECODE
+    launcher.inflight_num_decode += 1
+
+    launcher.inflight_num_prefill = 0
+    launcher.inflight_num_decode = 0
+    assert launcher._get_next_instance_type(1, 1, [1, 2]) == InstanceType.DECODE
+    assert launcher._get_next_instance_type(1, 2, [1, 2]) == InstanceType.PREFILL
+
+    assert launcher._get_next_instance_type(3, 5, [1, 2]) == InstanceType.DECODE
+    assert launcher._get_next_instance_type(3, 6, [1, 2]) == InstanceType.PREFILL
+    assert launcher._get_next_instance_type(3, 7, [1, 2]) == InstanceType.PREFILL
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("request_output_queue_type", ['rayqueue', 'zmq'])
+async def test_pd_disagg_gloal_launch_deployment_and_auto_scale_up_loop(ray_env, request_output_queue_type):
+    manager, _, _, _, _ = init_manager_with_launch_mode(LaunchMode.GLOBAL, request_output_queue_type,
+                                                        enable_pd_disagg=True, pd_ratio="1:1")
+    await asyncio.sleep(30.0)
+
+    num_instances = manager.scale_up([], [], [])
+    assert num_instances == 4
+    curr_pgs, curr_servers, curr_instances = await manager.get_cluster_deployment()
+    assert len(curr_pgs) == 4 and len(curr_servers) == 4 and len(curr_instances) == 4
+
+    num_prefill_instances = 0
+    num_decode_instances = 0
+    prefill_instance_ids = []
+    decode_instance_ids = []
+    for _, instance_handle in curr_instances.items():
+        instance_type = ray.get(instance_handle.get_instance_args.remote()).instance_type
+        if instance_type == InstanceType.PREFILL:
+            num_prefill_instances += 1
+            prefill_instance_ids.append(ray.get(instance_handle.get_instance_info.remote()).instance_id)
+        elif instance_type == InstanceType.DECODE:
+            num_decode_instances += 1
+            decode_instance_ids.append(ray.get(instance_handle.get_instance_info.remote()).instance_id)
+
+    assert torch.cuda.device_count() == 4
+    assert num_prefill_instances == 2 and num_decode_instances == 2
+    assert set(prefill_instance_ids).union(set(decode_instance_ids)) == set(curr_instances.keys())
+
+    kill_instance(prefill_instance_ids[0])
+    await asyncio.sleep(10.0)
+
+    kill_instance(prefill_instance_ids[1])
+    await asyncio.sleep(10.0)
+
+    kill_instance(decode_instance_ids[1])
+    await asyncio.sleep(90.0)
+    alive_decode_instance_id = decode_instance_ids[0]
+
+    num_instances = manager.scale_up([], [], [])
+    assert num_instances == 4
+    curr_pgs, curr_servers, curr_instances = await manager.get_cluster_deployment()
+    assert len(curr_pgs) == 4 and len(curr_servers) == 4 and len(curr_instances) == 4
+
+    num_prefill_instances = 0
+    num_decode_instances = 0
+    decode_instance_ids = []
+    for instance_id, instance_handle in curr_instances.items():
+        instance_type = ray.get(instance_handle.get_instance_args.remote()).instance_type
+        if instance_type == InstanceType.PREFILL:
+            num_prefill_instances += 1
+        elif instance_type == InstanceType.DECODE:
+            num_decode_instances += 1
+            decode_instance_ids.append(instance_id)
+
+    assert num_prefill_instances == 2 and num_decode_instances == 2
+    assert alive_decode_instance_id in decode_instance_ids
+
+@pytest.mark.asyncio
+async def test_pd_disagg_deployment_states():
+    manager_args = ManagerArgs(enable_migration=True, enable_pd_disagg=True, pd_ratio="1:2")
+    engine_args = EngineArgs(model="facebook/opt-125m", worker_use_ray=True)
+    manager = Manager(entrypoints_args=EntrypointsArgs(), manager_args=manager_args,
+                      instance_args=InstanceArgs(migration_backend="rayrpc"),
+                      engine_args=engine_args, launch_args=LaunchArgs(LaunchMode.LOCAL, BackendType.VLLM),
+                      work_dir=os.getcwd())
+    assert not manager._inner_check_pd_deployment()
+
+    prefill_instance_ids = [random_uuid() for _ in range(3)]
+    decode_instance_ids = [random_uuid() for _ in range(3)]
+
+    manager.scale_up(prefill_instance_ids, [None]*len(prefill_instance_ids),
+                     [InstanceArgs(instance_type="prefill")]*len(prefill_instance_ids))
+    assert manager._inner_check_pd_deployment() in prefill_instance_ids
+
+    manager.scale_down(prefill_instance_ids)
+    manager.scale_up(decode_instance_ids, [None]*len(decode_instance_ids),
+                     [InstanceArgs(instance_type="decode")]*len(decode_instance_ids))
+    assert manager._inner_check_pd_deployment() in decode_instance_ids
+
+    manager.scale_up(prefill_instance_ids, [None]*len(prefill_instance_ids),
+                     [InstanceArgs(instance_type="prefill")]*len(prefill_instance_ids))
+    assert not manager._inner_check_pd_deployment()

--- a/tests/unit_test/llumlet/test_migration_coordinator.py
+++ b/tests/unit_test/llumlet/test_migration_coordinator.py
@@ -38,7 +38,7 @@ async def test_migrate_out_onestage(ray_env):
     migrate_out_request = MagicMock()
 
     # Create an instance of MigrationCoordinator
-    coordinator = MigrationCoordinator(backend_engine, last_stage_max_blocks=1, max_stages=3)
+    coordinator = MigrationCoordinator(backend_engine, migration_last_stage_max_blocks=1, migration_max_stages=3)
 
     # Mock method return values and test data
     src_blocks = [1, 2, 3]
@@ -97,8 +97,8 @@ async def test_migrate_out_running_request(_, ray_env):
     migrate_out_request = MockRequest("1", 1, math.inf)
 
     # Create an instance of MigrationCoordinator
-    max_stages = 3
-    coordinator = MigrationCoordinator(backend_engine, 1, max_stages)
+    migration_max_stages = 3
+    coordinator = MigrationCoordinator(backend_engine, 1, migration_max_stages)
     migrate_in_ray_actor = MagicMock()
     migrate_in_ray_actor.execute_engine_method = MagicMock()
     migrate_in_ray_actor.execute_engine_method.remote = MagicMock()
@@ -109,13 +109,13 @@ async def test_migrate_out_running_request(_, ray_env):
     assert coordinator._migrate_out_onestage.call_count == 1
     assert status == MigrationStatus.FINISHED
 
-    max_stages = 3
+    migration_max_stages = 3
     coordinator._migrate_out_onestage.side_effect = [MigrationStatus.RUNNING,
                                                      MigrationStatus.RUNNING,
                                                      MigrationStatus.RUNNING,
                                                      MigrationStatus.RUNNING]
     status = await coordinator.migrate_out_running_request(migrate_in_ray_actor, migrate_out_request)
-    assert coordinator._migrate_out_onestage.call_count == max_stages + 1
+    assert coordinator._migrate_out_onestage.call_count == migration_max_stages + 1
     assert status == MigrationStatus.ABORTED_SRC
 
 @pytest.mark.asyncio
@@ -126,7 +126,7 @@ async def test_migrate_out_waiting_request():
     migrate_out_request = MagicMock()
 
     # Create an instance of MigrationCoordinator
-    coordinator = MigrationCoordinator(backend_engine, last_stage_max_blocks=1, max_stages=3)
+    coordinator = MigrationCoordinator(backend_engine, migration_last_stage_max_blocks=1, migration_max_stages=3)
 
     # Test FINISHED
     migrate_out_request.prefill_num_blocks = 3


### PR DESCRIPTION
1. move the instance level args from ManagerArgs to InstanceArgs
2. move launch functions from manager to new file launcher.py
3. Increase the instance type when scaling up llumlet ['prefill', 'decode', 'no_constraints']
4. Remove --num-dispatched-instance parameters，use `--pd-ratio` to determine the instance type when launching instance under global launch context.
5. compute dispatch_load_metric and migration_load_metric in llumlet.
6. add pd-disadd test for bench_test and correctness_test

