### PR TITLE
Fix bug #100: Performance Comparison Between vLLM and Llumnix Deployment

### DIFF
--- a/llumnix/backends/vllm/sim_llm_engine.py
+++ b/llumnix/backends/vllm/sim_llm_engine.py
@@ -47,8 +47,9 @@ class BackendSimVLLM(BackendVLLM):
                                                                           instance_id=instance_id,
                                                                           placement_group=placement_group,
                                                                           latency_mem=latency_mem)
-        self.engine.scheduler = [SchedulerLlumnix(self.engine.scheduler_config, self.engine.cache_config, self.engine.lora_config)
-                                 for _ in range(engine_args.pipeline_parallel_size)]
+        self.engine.scheduler = [SchedulerLlumnix(self.engine.scheduler_config, self.engine.cache_config, self.engine.lora_config,
+                             engine_args.pipeline_parallel_size, self.engine.async_callbacks[v_id])
+            for v_id in range(engine_args.pipeline_parallel_size)]
         for vid in range(engine_args.pipeline_parallel_size):
             self.engine.scheduler[vid].add_update_instance_info_callback(self.engine.update_instance_info)
         self.engine.output_processor.scheduler = self.engine.scheduler


### PR DESCRIPTION
1.	Fixed the issue where use_async_output_proc was set to false due to the incorrect initialization of self.engine.scheduler.