### PR TITLE
[Core] Support async output processing when disabling migration

### DIFF
--- a/.github/workflows/bench_test.yml
+++ b/.github/workflows/bench_test.yml
@@ -20,7 +20,7 @@ jobs:
   bench_tests:
     needs: cancel_previous_workflows
     runs-on: [self-hosted]
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test: check_pytest_installed
 
 .PHONY: unit_test
 unit_test: check_pytest_installed
-	@pytest -v -s --tb=long --ignore=third_party --ignore=tests/e2e_test --disable-warnings
+	@pytest -v --ignore=third_party --ignore=tests/e2e_test --disable-warnings
 
 .PHONY: offline_test
 offline_test:

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test: check_pytest_installed
 
 .PHONY: unit_test
 unit_test: check_pytest_installed
-	@pytest -v --ignore=third_party --ignore=tests/e2e_test --disable-warnings
+	@pytest -v -s --tb=long --ignore=third_party --ignore=tests/e2e_test --disable-warnings
 
 .PHONY: offline_test
 offline_test:

--- a/llumnix/arg_utils.py
+++ b/llumnix/arg_utils.py
@@ -366,7 +366,7 @@ class InstanceArgs:
 
     @classmethod
     def check_args(cls, args: 'InstanceArgs', manager_args: ManagerArgs,
-                   launch_model: LaunchMode, parser: argparse.ArgumentParser):
+                   launch_mode: LaunchMode, parser: argparse.ArgumentParser):
         # pylint: disable=protected-access
         for action in parser._optionals._actions:
             if hasattr(action, 'choices') and action.choices is not None and hasattr(args, action.dest):
@@ -376,7 +376,7 @@ class InstanceArgs:
             "Set profiling_result_file_path args when enable simulator mode"
 
         # instance_type check
-        if manager_args.enable_pd_disagg and launch_model == LaunchMode.LOCAL:
+        if manager_args.enable_pd_disagg and launch_mode == LaunchMode.LOCAL:
             assert args.instance_type in ['prefill', 'decode'], \
                 "instance_type should be prefill or decode if enable_pd_disagg is set."
 

--- a/llumnix/backends/vllm/sim_executor.py
+++ b/llumnix/backends/vllm/sim_executor.py
@@ -77,7 +77,9 @@ class SimGPUExecutor(RayGPUExecutor):
             decode_meta_data = (decode_bs, decode_seq_len)
             latency += self.latency_mem.decode_latency[decode_meta_data][0] if decode_meta_data in self.latency_mem.decode_latency \
                        else model_decode((decode_bs, decode_seq_len), *self.latency_mem.decode_model_params)
+
         await asyncio.sleep(latency/1000)
+
         sampler_outputs = []
         for meta_data in execute_model_req.seq_group_metadata_list:
             samples = []
@@ -87,6 +89,7 @@ class SimGPUExecutor(RayGPUExecutor):
             if samples:
                 output = CompletionSequenceGroupOutput(samples, None)
                 sampler_outputs.append(output)
+
         return [SamplerOutput(outputs=sampler_outputs)]
 
     async def send_blocks(self, blocks_len) -> None:

--- a/llumnix/entrypoints/vllm/arg_utils.py
+++ b/llumnix/entrypoints/vllm/arg_utils.py
@@ -1,14 +1,17 @@
+from typing import Tuple
+
 from vllm.engine.arg_utils import AsyncEngineArgs
 
 from llumnix.logging.logger import init_logger
 from llumnix.backends.backend_interface import BackendType
 from llumnix.backends.vllm.utils import check_engine_args
 from llumnix.arg_utils import EntrypointsArgs, ManagerArgs, InstanceArgs, LlumnixArgumentParser
+from llumnix.entrypoints.utils import LaunchMode
 
 logger = init_logger(__name__)
 
 
-def add_cli_args(parser: LlumnixArgumentParser):
+def add_cli_args(parser: LlumnixArgumentParser) -> "Namespace":
     parser.set_namespace("llumnix")
     parser = EntrypointsArgs.add_cli_args(parser)
     parser = ManagerArgs.add_cli_args(parser)
@@ -16,9 +19,11 @@ def add_cli_args(parser: LlumnixArgumentParser):
     parser.set_namespace("vllm")
     parser = AsyncEngineArgs.add_cli_args(parser)
     cli_args = parser.parse_args()
+
     return cli_args
 
-def get_args(cfg, launch_model, parser, cli_args):
+def get_args(cfg, launch_mode: LaunchMode, parser: LlumnixArgumentParser, cli_args: "Namespace") \
+        -> Tuple[EntrypointsArgs, ManagerArgs, InstanceArgs, AsyncEngineArgs]:
     engine_args = AsyncEngineArgs.from_cli_args(cli_args)
     instance_args: InstanceArgs = InstanceArgs.from_llumnix_config(cfg)
     instance_args.init_from_engine_args(engine_args, BackendType.VLLM)
@@ -28,8 +33,8 @@ def get_args(cfg, launch_model, parser, cli_args):
 
     EntrypointsArgs.check_args(entrypoints_args, parser)
     ManagerArgs.check_args(manager_args, parser)
-    InstanceArgs.check_args(instance_args, manager_args, launch_model, parser)
-    check_engine_args(engine_args, instance_args)
+    InstanceArgs.check_args(instance_args, manager_args, launch_mode, parser)
+    check_engine_args(engine_args, manager_args, instance_args)
 
     logger.info("entrypoints_args: {}".format(entrypoints_args))
     logger.info("manager_args: {}".format(manager_args))

--- a/tests/unit_test/backends/vllm/test_migration.py
+++ b/tests/unit_test/backends/vllm/test_migration.py
@@ -111,7 +111,8 @@ async def test_migration_correctness(ray_env, migration_backend, migration_reque
     if migration_backend == 'nccl' and tensor_parallel_size == 2:
         pytest.skip("When the migration backend is nccl, Llumnix does not support tensor parallelism.")
 
-    engine_args = EngineArgs(model="facebook/opt-125m", worker_use_ray=True, tensor_parallel_size=tensor_parallel_size, disable_async_output_proc=True)
+    engine_args = EngineArgs(model="facebook/opt-125m", worker_use_ray=True, tensor_parallel_size=tensor_parallel_size,
+                             disable_async_output_proc=True)
     id_rank_map = {"0": 0, "1": 1}
     if migration_request_status == 'running':
         request_migration_policy = "SR"

--- a/tests/unit_test/backends/vllm/test_migration.py
+++ b/tests/unit_test/backends/vllm/test_migration.py
@@ -111,7 +111,7 @@ async def test_migration_correctness(ray_env, migration_backend, migration_reque
     if migration_backend == 'nccl' and tensor_parallel_size == 2:
         pytest.skip("When the migration backend is nccl, Llumnix does not support tensor parallelism.")
 
-    engine_args = EngineArgs(model="facebook/opt-125m", worker_use_ray=True, tensor_parallel_size=tensor_parallel_size)
+    engine_args = EngineArgs(model="facebook/opt-125m", worker_use_ray=True, tensor_parallel_size=tensor_parallel_size, disable_async_output_proc=True)
     id_rank_map = {"0": 0, "1": 1}
     if migration_request_status == 'running':
         request_migration_policy = "SR"
@@ -227,7 +227,7 @@ async def test_migration_correctness(ray_env, migration_backend, migration_reque
 @pytest.mark.parametrize("migration_backend", ['rayrpc', 'gloo', 'nccl'])
 @pytest.mark.asyncio
 async def test_pd_diaggregation_correctness(ray_env, migration_backend):
-    engine_args = EngineArgs(model="facebook/opt-125m", worker_use_ray=True)
+    engine_args = EngineArgs(model="facebook/opt-125m", worker_use_ray=True, disable_async_output_proc=True)
     id_rank_map = {"0":0, "1":1}
 
     instance_args = InstanceArgs()

--- a/tests/unit_test/backends/vllm/test_simulator.py
+++ b/tests/unit_test/backends/vllm/test_simulator.py
@@ -84,10 +84,10 @@ async def test_backend(ray_env):
     class DummyActor:
         def __init__(self):
             pass
-    dummy_actor = ray.remote(num_cpus=1,
-                             name="instance_0",
-                             namespace='llumnix')(DummyActor)
-    dummy_actor = dummy_actor.remote()
+    dummy_actor_class = ray.remote(num_cpus=1,
+                                   name="instance_0",
+                                   namespace='llumnix')(DummyActor)
+    dummy_actor = dummy_actor_class.remote()
     placement_group = initialize_placement_group(get_placement_group_name("0"), num_cpus=2, num_gpus=0, detached=True)
     sim_backend = MockBackendSim(instance_id="0",
                                  request_output_queue_type=request_output_queue_type,


### PR DESCRIPTION
This pr is based on the [pr](https://github.com/AlibabaPAI/llumnix/pull/110) contributed by @Ronniexie, addressing the [issue](https://github.com/AlibabaPAI/llumnix/issues/100). 
Currenly, async output processing is only supported when disabling migration. We are implementing new live migration codes supporting async output processing and use_ray_spmd_worker.