### PR TITLE
[Scalability] Not wait ray remote call in generate and abort to improve throughput

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ def ray_start():
     raise Exception("Ray start failed after 5 attempts.")
 
 def ray_stop():
-    subprocess.run(["ray", "stop", "--force"], check=False, stdout=subprocess.DEVNULL)
+    subprocess.run(["ray", "stop"], check=False, stdout=subprocess.DEVNULL)
 
 def cleanup_ray_env_func():
     try:

--- a/tests/unit_test/global_scheduler/test_manager.py
+++ b/tests/unit_test/global_scheduler/test_manager.py
@@ -255,6 +255,7 @@ def test_generate_and_abort(ray_env, manager, llumlet):
     assert num_requests == 0
     server_info = ServerInfo(None, None, None, None, None)
     ray.get(manager.generate.remote(request_id, server_info, math.inf, None, None))
+    time.sleep(1.0)
     num_requests = ray.get(llumlet.get_num_requests.remote())
     assert num_requests == 1
     ray.get(manager.abort.remote(request_id))


### PR DESCRIPTION
Previously, wait remote call will take 2ms. So the throughput of generate is around 512 req/s. In this pr, without waiting ray remote call, generate will only take under 1ms. So the throughput of generate is above 1024 req/s.