### PR TITLE
[BladeLLM] support dispatch decode instance in manager when using bladellm

### DIFF
--- a/docs/Arguments.md
+++ b/docs/Arguments.md
@@ -61,6 +61,7 @@ usage: -m llumnix.entrypoints.vllm.api_server [-h]
             [--enable-port-increment]
             [--enable-port-offset-store]
             [--instance-type INSTANCE_TYPE]
+            [--use-podname-as-engine-disagg-instance-id]
 
 ```
 
@@ -277,6 +278,9 @@ usage: -m llumnix.entrypoints.vllm.api_server [-h]
 `--instance-type`
 - Instance types for the engine.
 - Possible choices: prefill, decode, no_constraints
+
+`--use-podname-as-engine-disagg-instance-id`
+- Use envorinment variable POD_NAME as engine instance id.
 
 # Unsupported vLLM feature options
 

--- a/docs/Arguments.md
+++ b/docs/Arguments.md
@@ -61,7 +61,7 @@ usage: -m llumnix.entrypoints.vllm.api_server [-h]
             [--enable-port-increment]
             [--enable-port-offset-store]
             [--instance-type INSTANCE_TYPE]
-            [--use-podname-as-engine-disagg-instance-id]
+            [--engine-disagg-inst-id-env-var]
 
 ```
 
@@ -279,8 +279,8 @@ usage: -m llumnix.entrypoints.vllm.api_server [-h]
 - Instance types for the engine.
 - Possible choices: prefill, decode, no_constraints
 
-`--use-podname-as-engine-disagg-instance-id`
-- Use envorinment variable POD_NAME as engine instance id.
+`--engine-disagg-inst-id-env-var`
+- Use which envorinment variable as engine instance id.
 
 # Unsupported vLLM feature options
 

--- a/docs/Arguments.md
+++ b/docs/Arguments.md
@@ -280,7 +280,7 @@ usage: -m llumnix.entrypoints.vllm.api_server [-h]
 - Possible choices: prefill, decode, no_constraints
 
 `--engine-disagg-inst-id-env-var`
-- Use which envorinment variable as engine instance id.
+- specify which environment variable to use as the engine instance id.
 
 # Unsupported vLLM feature options
 

--- a/llumnix/arg_utils.py
+++ b/llumnix/arg_utils.py
@@ -383,6 +383,7 @@ class InstanceArgs:
     kvtransfer_migration_backend_naming_url: str = None
     migration_last_stage_max_blocks: int = None
     migration_max_stages: int = None
+    use_podname_as_engine_disagg_instance_id: bool = None
 
     # init from engine args
     enable_engine_pd_disagg: bool = None
@@ -522,4 +523,7 @@ class InstanceArgs:
         parser.add_argument('--migration-last-stage-max-blocks',
                             type=int,
                             help='if the number pf remain blocks < migration_last_stage_max_blocks, do last stage migration')
+        parser.add_argument('--use-podname-as-engine-disagg-instance-id',
+                            action='store_true',
+                            help='use environment variable POD_NAME as engine instance id, only need in bladellm')
         return parser

--- a/llumnix/arg_utils.py
+++ b/llumnix/arg_utils.py
@@ -383,7 +383,7 @@ class InstanceArgs:
     kvtransfer_migration_backend_naming_url: str = None
     migration_last_stage_max_blocks: int = None
     migration_max_stages: int = None
-    use_podname_as_engine_disagg_instance_id: bool = None
+    engine_disagg_inst_id_env_var: str = None
 
     # init from engine args
     enable_engine_pd_disagg: bool = None
@@ -523,7 +523,7 @@ class InstanceArgs:
         parser.add_argument('--migration-last-stage-max-blocks',
                             type=int,
                             help='if the number pf remain blocks < migration_last_stage_max_blocks, do last stage migration')
-        parser.add_argument('--use-podname-as-engine-disagg-instance-id',
-                            action='store_true',
-                            help='use environment variable POD_NAME as engine instance id, only need in bladellm')
+        parser.add_argument('--engine-disagg-inst-id-env-var',
+                            type=str,
+                            help='environment variable used as engine instance id')
         return parser

--- a/llumnix/backends/bladellm/llm_engine.py
+++ b/llumnix/backends/bladellm/llm_engine.py
@@ -463,6 +463,8 @@ class BackendBladeLLM(BackendInterface):
     async def add_request(self, request_id: str, server_info: ServerInfo, expected_steps: int, *args, **kwargs) -> None:
         assert "server_request" in kwargs and kwargs["server_request"]
         server_request = ServerRequest(**json.loads(kwargs["server_request"]))
+        # The instance ID of the decode instance. If provided, engine will skip dispatch decode instance after prefilling.
+        server_request.decode_instances = [kwargs.get("decode_instance_id", ""),]
         await self.engine.add_request(server_info, server_request)
 
     def abort_request(self, request_id: Union[str, Iterable[str]]) -> None:

--- a/llumnix/config/default.py
+++ b/llumnix/config/default.py
@@ -126,6 +126,8 @@ _C.INSTANCE.INSTANCE_TYPE = "no_constraints"
 _C.INSTANCE.SIMULATOR_MODE = False
 # Profiling result file path when using simulator
 _C.INSTANCE.PROFILING_RESULT_FILE_PATH = None
+# use environment variable POD_NAME as bladellm engine instance id
+_C.INSTANCE.USE_PODNAME_AS_ENGINE_DISAGG_INSTANCE_ID = False
 
 # ------------------------- LOAD METRICS CONFIGURATION ------------------------
 # Instance dispatch load metric

--- a/llumnix/config/default.py
+++ b/llumnix/config/default.py
@@ -126,8 +126,8 @@ _C.INSTANCE.INSTANCE_TYPE = "no_constraints"
 _C.INSTANCE.SIMULATOR_MODE = False
 # Profiling result file path when using simulator
 _C.INSTANCE.PROFILING_RESULT_FILE_PATH = None
-# use environment variable POD_NAME as bladellm engine instance id
-_C.INSTANCE.USE_PODNAME_AS_ENGINE_DISAGG_INSTANCE_ID = False
+# environment variable used as bladellm engine instance id
+_C.INSTANCE.ENGINE_DISAGG_INST_ID_ENV_VAR = None
 
 # ------------------------- LOAD METRICS CONFIGURATION ------------------------
 # Instance dispatch load metric

--- a/llumnix/entrypoints/bladellm/api_server.py
+++ b/llumnix/entrypoints/bladellm/api_server.py
@@ -109,9 +109,9 @@ def setup_llumnix_api_server(engine_args: ServingArgs, loop: asyncio.AbstractEve
         engine_args_llumnix = BladellmEngineArgs()
         engine_args_llumnix.engine_args = pickle.dumps(engine_args)
         engine_args_llumnix.world_size = engine_args.tensor_parallel_size * engine_args.pipeline_parallel_size
-        if engine_args.disable_optinons is not None:
+        if engine_args.disagg_options is not None:
             engine_args_llumnix.instance_id = engine_args.disagg_options.inst_id
-      
+
         global entrypoints_context
         entrypoints_context = setup_llumnix(entrypoints_args, manager_args, instance_args, engine_args_llumnix, launch_args)
         llumnix_client = LlumnixClientBladeLLM(engine_args, entrypoints_context, loop)

--- a/llumnix/entrypoints/bladellm/api_server.py
+++ b/llumnix/entrypoints/bladellm/api_server.py
@@ -109,6 +109,9 @@ def setup_llumnix_api_server(engine_args: ServingArgs, loop: asyncio.AbstractEve
         engine_args_llumnix = BladellmEngineArgs()
         engine_args_llumnix.engine_args = pickle.dumps(engine_args)
         engine_args_llumnix.world_size = engine_args.tensor_parallel_size * engine_args.pipeline_parallel_size
+        if engine_args.disable_optinons is not None:
+            engine_args_llumnix.instance_id = engine_args.disagg_options.inst_id
+      
         global entrypoints_context
         entrypoints_context = setup_llumnix(entrypoints_args, manager_args, instance_args, engine_args_llumnix, launch_args)
         llumnix_client = LlumnixClientBladeLLM(engine_args, entrypoints_context, loop)

--- a/llumnix/entrypoints/bladellm/arg_utils.py
+++ b/llumnix/entrypoints/bladellm/arg_utils.py
@@ -29,6 +29,7 @@ logger = init_logger(__name__)
 class BladellmEngineArgs:
     engine_args: bytes = None
     world_size: int = None
+    instance_id: str = None
 
 
 def add_llumnix_cli_args(parser: LlumnixArgumentParser) -> LlumnixArgumentParser:

--- a/llumnix/global_scheduler/dispatch_scheduler.py
+++ b/llumnix/global_scheduler/dispatch_scheduler.py
@@ -11,10 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Set
+from typing import Dict
 
 from llumnix.logging.logger import init_logger
-from llumnix.instance_info import InstanceInfo, InstanceType
+from llumnix.instance_info import InstanceInfo
 from llumnix.constants import DISPATCH_LOG_FREQUENCY
 from llumnix.global_scheduler.dispatch_policy import DispatchPolicyFactory
 
@@ -27,36 +27,22 @@ class DispatchScheduler:
                  topk_random_dispatch: int) -> None:
         self.dispatch_policy = DispatchPolicyFactory.get_policy(dispatch_policy)
         self.topk_random_dispatch = topk_random_dispatch
-        self.available_dispatch_instance_set: Set[str] = set()
-        self.instance_info: Dict[str, InstanceInfo] = {}
+
         # statistics
         self.total_num_requests = 0
-        self.instance_num_requests: Dict[str, int] = {}
 
-    def dispatch(self) -> str:
+    def dispatch(
+        self,
+        instance_info: Dict[str, InstanceInfo],
+        instance_num_requests: Dict[str, int]
+    ) -> str:
         self.total_num_requests += 1
-        dispatch_instance_id = self.dispatch_policy.dispatch(self.instance_num_requests,
-                                                             self.instance_info.values(),
-                                                             self.topk_random_dispatch)
-        self.instance_num_requests[dispatch_instance_id] += 1
+        dispatch_instance_id = self.dispatch_policy.dispatch(
+            instance_num_requests, instance_info.values(), self.topk_random_dispatch
+        )
+
         if self.total_num_requests % DISPATCH_LOG_FREQUENCY == 0:
             logger.info("dispatch scheduler total_dispatched_requests: {}".format(self.total_num_requests))
-            for instance_id, num_requests in self.instance_num_requests.items():
+            for instance_id, num_requests in instance_num_requests.items():
                 logger.info("instance {} num_dispatched_requests: {}".format(instance_id, num_requests))
         return dispatch_instance_id
-
-    def update_instance_infos(self, instance_infos: Dict[str, InstanceInfo]) -> None:
-        for instance_id, instance_info in instance_infos.items():
-            if instance_id not in self.available_dispatch_instance_set:
-                continue
-            self.instance_info[instance_id] = instance_info
-
-    def add_instance(self, instance_id: str, instance_type: InstanceType) -> None:
-        if instance_type in [InstanceType.NO_CONSTRAINTS, InstanceType.PREFILL]:
-            self.available_dispatch_instance_set.add(instance_id)
-            self.instance_num_requests[instance_id] = 0
-
-    def remove_instance(self, instance_id: str) -> None:
-        if instance_id in self.available_dispatch_instance_set:
-            self.available_dispatch_instance_set.remove(instance_id)
-            self.instance_num_requests.pop(instance_id, None)

--- a/llumnix/global_scheduler/global_scheduler.py
+++ b/llumnix/global_scheduler/global_scheduler.py
@@ -21,7 +21,6 @@ from llumnix.global_scheduler.dispatch_scheduler import DispatchScheduler
 from llumnix.global_scheduler.migration_scheduler import MigrationScheduler
 from llumnix.global_scheduler.migration_policy import PairMigrationConstraints
 from llumnix.global_scheduler.scaling_scheduler import ScalingScheduler
-from llumnix.instance_info import InstanceType
 
 logger = init_logger(__name__)
 

--- a/llumnix/global_scheduler/global_scheduler.py
+++ b/llumnix/global_scheduler/global_scheduler.py
@@ -16,7 +16,7 @@ import math
 
 from llumnix.logging.logger import init_logger
 from llumnix.internal_config import GlobalSchedulerConfig
-from llumnix.instance_info import InstanceInfo
+from llumnix.instance_info import InstanceInfo, InstanceType
 from llumnix.global_scheduler.dispatch_scheduler import DispatchScheduler
 from llumnix.global_scheduler.migration_scheduler import MigrationScheduler
 from llumnix.global_scheduler.migration_policy import PairMigrationConstraints
@@ -32,6 +32,12 @@ class GlobalScheduler:
         self.num_instances = 0
         self.instance_id_set: Set[str] = set()
         self.instance_info: Dict[str, InstanceInfo] = {}
+
+        self.available_prefill_instance_info: Dict[str, InstanceInfo] = {}
+        self.available_prefill_instance_num_requests: Dict[str, int] = {}
+
+        self.available_decode_instance_info: Dict[str, InstanceInfo] = {}
+        self.available_decode_instance_num_requests: Dict[str, int] = {}
 
         # dispatch args
         self.dispatch_scheduler = DispatchScheduler(global_scheduler_config.dispatch_policy,
@@ -52,20 +58,41 @@ class GlobalScheduler:
             if instance_info.instance_id in self.instance_id_set:
                 self.instance_info[instance_info.instance_id] = instance_info
 
-    def dispatch(self) -> str:
-        self.dispatch_scheduler.update_instance_infos(self.instance_info)
-        instance_id = self.dispatch_scheduler.dispatch()
-        request_expected_steps = 1 if self.global_scheduler_config.enable_pd_disagg else math.inf
+    def dispatch(self, instance_type: InstanceType = InstanceType.PREFILL) -> str:
+        if instance_type in (InstanceType.PREFILL, InstanceType.NO_CONSTRAINTS):
+            instance_id = self.dispatch_scheduler.dispatch(
+                instance_info=self.available_prefill_instance_info,
+                instance_num_requests=self.available_prefill_instance_num_requests,
+            )
+            self.available_prefill_instance_num_requests[instance_id] += 1
+        elif instance_type == InstanceType.DECODE:
+            instance_id = self.dispatch_scheduler.dispatch(
+                instance_info=self.available_decode_instance_info,
+                instance_num_requests=self.available_decode_instance_num_requests,
+            )
+            self.available_decode_instance_num_requests[instance_id] += 1
+        else:
+            logger.error("instance_type {} is not supported".format(instance_type))
+            raise TypeError("instance_type {} is not supported".format(instance_type))
+        if self.global_scheduler_config.enable_pd_disagg and instance_type in (
+            InstanceType.PREFILL,
+            InstanceType.NO_CONSTRAINTS,
+        ):
+            request_expected_steps = 1
+        else:
+            request_expected_steps = math.inf
         return instance_id, request_expected_steps
 
-    def pair_migration(self, pair_migration_type: PairMigrationConstraints) -> List[Tuple[str, str]]:
-        self.migration_scheduler.update_instance_infos(self.instance_info)
-        migrate_instance_pairs = self.migration_scheduler.pair_migration(pair_migration_type)
+    def pair_migration(
+        self, pair_migration_type: PairMigrationConstraints
+    ) -> List[Tuple[str, str]]:
+        migrate_instance_pairs = self.migration_scheduler.pair_migration(
+            instance_info=self.instance_info, pair_migration_type=pair_migration_type
+        )
         return migrate_instance_pairs
 
     def check_scale(self) -> Tuple[str, str]:
-        self.scaling_scheduler.update_instance_infos(self.instance_info)
-        scale_up_num, scale_down_num = self.scaling_scheduler.check_scale()
+        scale_up_num, scale_down_num = self.scaling_scheduler.check_scale(self.instance_info, self.instance_id_set)
         return scale_up_num, scale_down_num
 
     def scale_up(self, instance_id: Union[str, Iterable[str]], instance_type: List[InstanceType]) -> int:
@@ -88,28 +115,45 @@ class GlobalScheduler:
         instance_ids = list(instance_id)
         for ins_id in instance_ids:
             if ins_id in self.instance_id_set:
-                logger.info("Scale down instance: {}.".format(ins_id))
-                if ins_id in self.instance_info:
-                    del self.instance_info[ins_id]
-                else:
-                    logger.warning("instance {} is not in instance_info".format(ins_id))
                 self._remove_instance(ins_id)
         logger.info("num_instances: {}, instances: {}".format(self.num_instances, self.instance_id_set))
         return self.num_instances
 
     def _add_instance(self, instance_id: str, instance_type: InstanceType) -> None:
+        logger.info("Scale up instance: {}.".format(instance_id))
+        new_intance_info = self._get_empty_instance_info()
+        new_intance_info.instance_id = instance_id
+        new_intance_info.instance_type = instance_type
+        self.instance_info[instance_id] = new_intance_info
         self.instance_id_set.add(instance_id)
         self.num_instances = len(self.instance_id_set)
-        for scheduler in (self.dispatch_scheduler, self.migration_scheduler, self.scaling_scheduler):
-            scheduler.update_instance_infos(self.instance_info)
-            scheduler.add_instance(instance_id, instance_type)
+        if instance_type in (InstanceType.PREFILL, InstanceType.NO_CONSTRAINTS):
+            self.available_prefill_instance_info[instance_id] = new_intance_info
+            self.available_prefill_instance_num_requests[instance_id] = 0
+        elif instance_type == InstanceType.DECODE:
+            self.available_decode_instance_info[instance_id] = new_intance_info
+            self.available_decode_instance_num_requests[instance_id] = 0
 
     def _remove_instance(self, instance_id: str) -> None:
-        self.instance_id_set.remove(instance_id)
+        logger.info("Scale down instance: {}.".format(instance_id))
+        if instance_id not in self.instance_id_set:
+            logger.warning("instance {} is not in instance_id_set".format(instance_id))
+        if instance_id not in self.instance_info:
+            logger.warning("instance {} is not in instance_info".format(instance_id))
+        print(self.available_prefill_instance_num_requests)
+        print(self.available_prefill_instance_info)
+        instance_info = self.instance_info.get(instance_id, None)
+        if instance_info:
+            if instance_info.instance_type in (InstanceType.PREFILL, InstanceType.NO_CONSTRAINTS):
+                self.available_prefill_instance_info.pop(instance_id, 0)
+                self.available_prefill_instance_num_requests.pop(instance_id, 0)
+            elif instance_info.instance_type == InstanceType.DECODE:
+                self.available_decode_instance_info.pop(instance_id, 0)
+                self.available_decode_instance_num_requests.pop(instance_id, 0)
+
+        self.instance_id_set.discard(instance_id)
+        self.instance_info.pop(instance_id, 0)
         self.num_instances = len(self.instance_id_set)
-        for scheduler in (self.dispatch_scheduler, self.migration_scheduler, self.scaling_scheduler):
-            scheduler.update_instance_infos(self.instance_info)
-            scheduler.remove_instance(instance_id)
 
     def _get_empty_instance_info(self) -> InstanceInfo:
         return self.scaling_scheduler.get_empty_instance_info()

--- a/llumnix/global_scheduler/migration_scheduler.py
+++ b/llumnix/global_scheduler/migration_scheduler.py
@@ -14,7 +14,7 @@
 from typing import Dict, List, Tuple
 
 from llumnix.logging.logger import init_logger
-from llumnix.instance_info import InstanceInfo, InstanceType
+from llumnix.instance_info import InstanceInfo
 from llumnix.global_scheduler.migration_filter import MigrationInstanceFilter, MigrationFilterConfig, CustomFilter
 from llumnix.global_scheduler.migration_policy import PairMigrationConstraints, PairMigrationPolicyFactory
 

--- a/llumnix/global_scheduler/scaling_scheduler.py
+++ b/llumnix/global_scheduler/scaling_scheduler.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Tuple, Set
+from typing import Dict, Tuple, Set
 import numpy as np
 
 from llumnix.logging.logger import init_logger
@@ -32,24 +32,15 @@ class ScalingScheduler:
         self.scale_down_threshold = scale_down_threshold
         self.scaling_policy = ScalePolicyFactory.get_policy(scaling_policy, scaling_load_metric=scaling_load_metric)
 
-        self.num_instances = 0
-        self.instance_id_set: Set[str] = set()
         self.enable_pd_disagg = enable_pd_disagg
 
-        # instance info args
-        self.instance_info: Dict[str, InstanceInfo] = None
-        self.sorted_instance_infos: List[InstanceInfo] = None
-
-        # TODO(Xinyi): Tag instance type for scheduler, should be extended to auto-scaling for prefill/decode instances.
-        self.instance_type_id_set: Dict[InstanceType, Set[str]] = {instance_type: set() for instance_type in InstanceType}
-
-    def check_scale(self) -> Tuple[str, str]:
+    def check_scale(self, instance_info: Dict[str, InstanceInfo], instance_id_set: Set[str]) -> Tuple[str, str]:
         scale_up_num = 0
         scale_down_num = 0
         # if not all instances have returned instance_info, not scale
-        if len(self.instance_info.keys()) < self.num_instances:
+        if len(instance_info.keys()) < len(instance_id_set):
             return scale_up_num, scale_down_num
-        now_instances = [self.instance_info[instance_id] for instance_id in self.instance_id_set]
+        now_instances = [instance_info[instance_id] for instance_id in instance_id_set]
         load_metric_up = self.scaling_policy.compute_load_metric_up(now_instances)
         load_metric_down = self.scaling_policy.compute_load_metric_down(now_instances)
         if load_metric_up > self.scale_up_threshold:
@@ -60,22 +51,6 @@ class ScalingScheduler:
             scale_down_num = 1
         return scale_up_num, scale_down_num
 
-    def update_instance_infos(self, instance_info: Dict[str, InstanceInfo]) -> None:
-        self.instance_info = instance_info
-
-    def add_instance(self, instance_id: str, instance_type: InstanceType) -> None:
-        self.instance_id_set.add(instance_id)
-        self.num_instances = len(self.instance_id_set)
-        self.instance_type_id_set[instance_type].add(instance_id)
-
-    def remove_instance(self, instance_id: str) -> None:
-        if instance_id in self.instance_id_set:
-            self.instance_id_set.remove(instance_id)
-        for instance_type in InstanceType:
-            if instance_id in self.instance_type_id_set[instance_type]:
-                self.instance_type_id_set[instance_type].remove(instance_id)
-                break
-        self.num_instances = len(self.instance_id_set)
 
     def get_empty_instance_info(self) -> InstanceInfo:
         dummy_intance_info = InstanceInfo()

--- a/llumnix/global_scheduler/scaling_scheduler.py
+++ b/llumnix/global_scheduler/scaling_scheduler.py
@@ -15,7 +15,7 @@ from typing import Dict, Tuple, Set
 import numpy as np
 
 from llumnix.logging.logger import init_logger
-from llumnix.instance_info import InstanceInfo, InstanceType
+from llumnix.instance_info import InstanceInfo
 from llumnix.global_scheduler.scaling_policy import ScalePolicyFactory
 
 logger = init_logger(__name__)

--- a/llumnix/llumlet/llumlet.py
+++ b/llumnix/llumlet/llumlet.py
@@ -55,8 +55,8 @@ class Llumlet:
                 engine_args = pickle.loads(engine_args.engine_args)
             log_actor_ray_info(actor_class_name=self.__class__.__name__)
             self.instance_id = instance_id
-            if instance_args.use_podname_as_engine_disagg_instance_id:
-                self.engine_disagg_inst_id = os.environ.get("POD_NAME", instance_id)
+            if instance_args.engine_disagg_inst_id_env_var:
+                self.engine_disagg_inst_id = os.environ.get(instance_args.engine_disagg_inst_id_env_var, instance_id)
             elif getattr(engine_args, 'disagg_options', None) and getattr(engine_args.disagg_options, 'inst_id', None):
                 self.engine_disagg_inst_id = engine_args.disagg_options.inst_id
             else:

--- a/llumnix/llumlet/llumlet.py
+++ b/llumnix/llumlet/llumlet.py
@@ -55,7 +55,12 @@ class Llumlet:
                 engine_args = pickle.loads(engine_args.engine_args)
             log_actor_ray_info(actor_class_name=self.__class__.__name__)
             self.instance_id = instance_id
-            self.engine_instance_id = os.environ.get('POD_NAME', instance_id)
+            if instance_args.use_podname_as_engine_disagg_instance_id:
+                self.engine_disagg_inst_id = os.environ.get("POD_NAME", instance_id)
+            elif getattr(engine_args, 'disagg_options', None) and getattr(engine_args.disagg_options, 'inst_id', None):
+                self.engine_disagg_inst_id = engine_args.disagg_options.inst_id
+            else:
+                self.engine_disagg_inst_id =  instance_id
             logger.info("Llumlet(instance_id={}, backend_type={})".format(self.instance_id, backend_type))
             self.instance_args: InstanceArgs = instance_args
             self.actor_name = get_instance_name(instance_id)
@@ -65,7 +70,7 @@ class Llumlet:
                 enable_defrag=instance_args.enable_defrag
             )
             migration_config: MigrationConfig = instance_args.create_migration_config()
-            self.backend_engine: BackendInterface = init_backend_engine(self.engine_instance_id,
+            self.backend_engine: BackendInterface = init_backend_engine(self.instance_id,
                                                                         placement_group,
                                                                         request_output_queue_type,
                                                                         migration_config,
@@ -219,8 +224,8 @@ class Llumlet:
     def get_instance_type(self) -> InstanceType:
         return self.instance_args.instance_type
 
-    def get_engine_instance_id(self) -> str:
-        return self.engine_instance_id
+    def get_engine_disagg_inst_id(self) -> str:
+        return self.engine_disagg_inst_id
 
     def get_all_request_ids(self) -> List[str]:
         return self.backend_engine.get_all_request_ids()

--- a/llumnix/manager.py
+++ b/llumnix/manager.py
@@ -45,7 +45,6 @@ from llumnix.constants import (CLEAR_REQUEST_INSTANCE_INTERVAL, NO_INSTANCE_RETR
 from llumnix.scaler import Scaler
 from llumnix.metrics.timestamps import set_timestamp
 from llumnix.entrypoints.api_server_actor import APIServerActor
-from llumnix.instance_info import InstanceType
 
 logger = init_logger(__name__)
 
@@ -438,6 +437,18 @@ class Manager:
                 asyncio.create_task(self._rebuild_migration_backend())
 
         return self.num_instances
+
+    def get_num_prefill_decode_instances(self):
+        num_prefill_instances = len(self.global_scheduler.prefill_instance_info)
+        num_decode_instances = len(self.global_scheduler.decode_instance_info)
+
+        return num_prefill_instances, num_decode_instances
+
+    def get_prefill_decode_instance_id_set(self):
+        prefill_instance_id_set = set(self.global_scheduler.prefill_instance_info.keys())
+        decode_instance_id_set = set(self.global_scheduler.decode_instance_info.keys())
+        return prefill_instance_id_set, decode_instance_id_set
+
 
     # TODO(KuilongCui): Add comments for this function.
     async def _rebuild_migration_backend(self) -> None:

--- a/llumnix/manager.py
+++ b/llumnix/manager.py
@@ -169,7 +169,11 @@ class Manager:
         if self.log_requests:
             logger.info("manager receive request {}".format(request_id))
             logger.info("dispath request {} to instance {}".format(request_id, prefill_instance_id))
-            self.request_instance[request_id] = prefill_instance_id
+            if self.manager_args.enable_engine_pd_disagg:
+                logger.info("request {} specified decode instance {}".format(request_id, decode_instance_id))
+                self.request_instance[request_id] = decode_instance_id
+            else:
+                self.request_instance[request_id] = prefill_instance_id
 
     async def abort(self, request_id: Union[str, Iterable[str]]) -> None:
         if isinstance(request_id, str):

--- a/llumnix/manager.py
+++ b/llumnix/manager.py
@@ -438,17 +438,6 @@ class Manager:
 
         return self.num_instances
 
-    def get_num_prefill_decode_instances(self):
-        num_prefill_instances = len(self.global_scheduler.available_prefill_instance_info)
-        num_decode_instances = len(self.global_scheduler.available_decode_instance_info)
-
-        return num_prefill_instances, num_decode_instances
-
-    def get_prefill_decode_instance_id_set(self):
-        prefill_instance_id_set = set(self.global_scheduler.available_prefill_instance_info.values())
-        decode_instance_id_set = set(self.global_scheduler.available_decode_instance_info.values())
-        return prefill_instance_id_set, decode_instance_id_set
-
     # TODO(KuilongCui): Add comments for this function.
     async def _rebuild_migration_backend(self) -> None:
         # Wait for all instances to finish migration

--- a/llumnix/scaler.py
+++ b/llumnix/scaler.py
@@ -446,7 +446,15 @@ class Scaler:
         instance_ids: List[str] = []
         instances: List[Llumlet] = []
         for _ in range(self.manager_args.initial_instances):
-            instance_id = random_uuid()
+            if (
+                backend_type == BackendType.BLADELLM
+                and self.manager_args.enable_engine_pd_disagg
+                and engine_args.instance_id
+            ):
+                # use blade instance id as llumlet instance id
+                instance_id = engine_args.instance_id
+            else:
+                instance_id = random_uuid()
             placement_group = self._init_placement_group(get_placement_group_name(instance_id), engine_args, backend_type,
                                                          init_server=False, block=True)
             instance = self._init_instance(instance_id, instance_args, placement_group, request_output_queue_type,

--- a/tests/unit_test/global_scheduler/test_global_scheduler.py
+++ b/tests/unit_test/global_scheduler/test_global_scheduler.py
@@ -49,60 +49,60 @@ def test_add_instance_and_remove_instance(global_scheduler):
     assert global_scheduler.num_instances == 1
     assert len(global_scheduler.instance_info) == 1
     assert len(global_scheduler.instance_id_set) == 1
-    assert len(global_scheduler.available_prefill_instance_info) == 1
-    assert len(global_scheduler.available_decode_instance_info) == 0
-    assert global_scheduler.available_prefill_instance_num_requests['instance_1'] == 0
-    assert global_scheduler.available_decode_instance_num_requests.get("instance_1", None) is None
+    assert len(global_scheduler.prefill_instance_info) == 1
+    assert len(global_scheduler.decode_instance_info) == 0
+    assert global_scheduler.prefill_instance_num_requests['instance_1'] == 0
+    assert global_scheduler.decode_instance_num_requests.get("instance_1", None) is None
     assert 'instance_1' in global_scheduler.instance_id_set
 
     global_scheduler.scale_down('instance_1')
     assert global_scheduler.num_instances == 0
     assert len(global_scheduler.instance_info) == 0
     assert len(global_scheduler.instance_id_set) == 0
-    assert len(global_scheduler.available_prefill_instance_info) == 0
-    assert len(global_scheduler.available_decode_instance_info) == 0
-    assert global_scheduler.available_prefill_instance_num_requests.get("instance_1", None) is None
-    assert global_scheduler.available_decode_instance_num_requests.get("instance_1", None) is None
+    assert len(global_scheduler.prefill_instance_info) == 0
+    assert len(global_scheduler.decode_instance_info) == 0
+    assert global_scheduler.prefill_instance_num_requests.get("instance_1", None) is None
+    assert global_scheduler.decode_instance_num_requests.get("instance_1", None) is None
 
 
     global_scheduler.scale_up('instance_2', [InstanceArgs(instance_type="prefill")])
-    assert len(global_scheduler.available_prefill_instance_num_requests) == 1
-    assert global_scheduler.available_prefill_instance_num_requests['instance_2'] == 0
-    assert len(global_scheduler.available_prefill_instance_info) == 1
+    assert len(global_scheduler.prefill_instance_num_requests) == 1
+    assert global_scheduler.prefill_instance_num_requests['instance_2'] == 0
+    assert len(global_scheduler.prefill_instance_info) == 1
     assert len(global_scheduler.instance_id_set) == 1
     global_scheduler.scale_up('instance_3', [InstanceArgs(instance_type="prefill")])
-    assert len(global_scheduler.available_prefill_instance_num_requests) == 2
-    assert global_scheduler.available_prefill_instance_num_requests['instance_3'] == 0
-    assert len(global_scheduler.available_prefill_instance_info) == 2
+    assert len(global_scheduler.prefill_instance_num_requests) == 2
+    assert global_scheduler.prefill_instance_num_requests['instance_3'] == 0
+    assert len(global_scheduler.prefill_instance_info) == 2
     assert len(global_scheduler.instance_id_set) == 2
 
 
     global_scheduler.scale_down('instance_2')
-    assert len(global_scheduler.available_prefill_instance_info) == 1
+    assert len(global_scheduler.prefill_instance_info) == 1
     assert len(global_scheduler.instance_info) == 1
     global_scheduler.scale_down('instance_3')
-    assert len(global_scheduler.available_prefill_instance_info) == 0
+    assert len(global_scheduler.prefill_instance_info) == 0
     assert len(global_scheduler.instance_info) == 0
 
     # test decode instance
     global_scheduler.scale_up('instance_1', [InstanceArgs(instance_type="decode")])
-    assert len(global_scheduler.available_decode_instance_info) == 1
-    assert len(global_scheduler.available_prefill_instance_info) == 0
+    assert len(global_scheduler.decode_instance_info) == 1
+    assert len(global_scheduler.prefill_instance_info) == 0
     global_scheduler.scale_down('instance_1')
     assert global_scheduler.num_instances == 0
-    assert len(global_scheduler.available_decode_instance_num_requests) == 0
+    assert len(global_scheduler.decode_instance_num_requests) == 0
     assert len(global_scheduler.instance_info) == 0
     assert len(global_scheduler.instance_id_set) == 0
-    assert len(global_scheduler.available_prefill_instance_info) == 0
-    assert len(global_scheduler.available_decode_instance_info) == 0
+    assert len(global_scheduler.prefill_instance_info) == 0
+    assert len(global_scheduler.decode_instance_info) == 0
 
     global_scheduler.scale_up('instance_2', [InstanceArgs(instance_type="decode")])
-    assert len(global_scheduler.available_decode_instance_info) == 1
+    assert len(global_scheduler.decode_instance_info) == 1
     global_scheduler.scale_up('instance_3', [InstanceArgs(instance_type="decode")])
-    assert len(global_scheduler.available_decode_instance_info) == 2
+    assert len(global_scheduler.decode_instance_info) == 2
     assert global_scheduler.num_instances == 2
-    assert len(global_scheduler.available_decode_instance_num_requests) == 2
-    assert len(global_scheduler.available_prefill_instance_num_requests) == 0
+    assert len(global_scheduler.decode_instance_num_requests) == 2
+    assert len(global_scheduler.prefill_instance_num_requests) == 0
     assert len(global_scheduler.instance_info) == 2
     assert len(global_scheduler.instance_id_set) == 2
 

--- a/tests/unit_test/global_scheduler/test_global_scheduler.py
+++ b/tests/unit_test/global_scheduler/test_global_scheduler.py
@@ -18,7 +18,6 @@ from llumnix.internal_config import GlobalSchedulerConfig
 from llumnix.global_scheduler.global_scheduler import GlobalScheduler
 from llumnix.instance_info import InstanceInfo, InstanceLoadCalculator, InstanceType
 from llumnix.utils import random_uuid
-from llumnix.instance_info import InstanceType
 
 from .test_manager import get_instance_info_migrate_in, get_instance_info_migrate_out
 
@@ -45,7 +44,7 @@ def global_scheduler():
 
 def test_add_instance_and_remove_instance(global_scheduler):
     # test prefill instance
-    global_scheduler.scale_up('instance_1', [InstanceArgs(instance_type="no_constraints")])
+    global_scheduler.scale_up('instance_1', [InstanceType.NO_CONSTRAINTS])
     assert global_scheduler.num_instances == 1
     assert len(global_scheduler.instance_info) == 1
     assert len(global_scheduler.instance_id_set) == 1
@@ -65,12 +64,12 @@ def test_add_instance_and_remove_instance(global_scheduler):
     assert global_scheduler.decode_instance_num_requests.get("instance_1", None) is None
 
 
-    global_scheduler.scale_up('instance_2', [InstanceArgs(instance_type="prefill")])
+    global_scheduler.scale_up('instance_2', [InstanceType.PREFILL])
     assert len(global_scheduler.prefill_instance_num_requests) == 1
     assert global_scheduler.prefill_instance_num_requests['instance_2'] == 0
     assert len(global_scheduler.prefill_instance_info) == 1
     assert len(global_scheduler.instance_id_set) == 1
-    global_scheduler.scale_up('instance_3', [InstanceArgs(instance_type="prefill")])
+    global_scheduler.scale_up('instance_3', [InstanceType.PREFILL])
     assert len(global_scheduler.prefill_instance_num_requests) == 2
     assert global_scheduler.prefill_instance_num_requests['instance_3'] == 0
     assert len(global_scheduler.prefill_instance_info) == 2
@@ -85,7 +84,7 @@ def test_add_instance_and_remove_instance(global_scheduler):
     assert len(global_scheduler.instance_info) == 0
 
     # test decode instance
-    global_scheduler.scale_up('instance_1', [InstanceArgs(instance_type="decode")])
+    global_scheduler.scale_up('instance_1', [InstanceType.DECODE])
     assert len(global_scheduler.decode_instance_info) == 1
     assert len(global_scheduler.prefill_instance_info) == 0
     global_scheduler.scale_down('instance_1')
@@ -96,9 +95,9 @@ def test_add_instance_and_remove_instance(global_scheduler):
     assert len(global_scheduler.prefill_instance_info) == 0
     assert len(global_scheduler.decode_instance_info) == 0
 
-    global_scheduler.scale_up('instance_2', [InstanceArgs(instance_type="decode")])
+    global_scheduler.scale_up('instance_2', [InstanceType.DECODE])
     assert len(global_scheduler.decode_instance_info) == 1
-    global_scheduler.scale_up('instance_3', [InstanceArgs(instance_type="decode")])
+    global_scheduler.scale_up('instance_3', [InstanceType.DECODE])
     assert len(global_scheduler.decode_instance_info) == 2
     assert global_scheduler.num_instances == 2
     assert len(global_scheduler.decode_instance_num_requests) == 2
@@ -148,12 +147,12 @@ def test_dispatch_decode(global_scheduler):
     prefill_instance_infos = init_instance_infos(initial_instances)
     prefill_instance_ids = [instance_info.instance_id for instance_info in prefill_instance_infos]
     global_scheduler.global_scheduler_config.enable_pd_disagg = True
-    global_scheduler.scale_up(prefill_instance_ids, [InstanceArgs(instance_type="prefill")]*len(prefill_instance_ids))
+    global_scheduler.scale_up(prefill_instance_ids, [InstanceType.PREFILL]*len(prefill_instance_ids))
     global_scheduler.update_instance_infos(prefill_instance_infos)
 
     decode_instance_infos = init_instance_infos(initial_instances)
     decode_instance_ids = [instance_info.instance_id for instance_info in decode_instance_infos]
-    global_scheduler.scale_up(decode_instance_ids, [InstanceArgs(instance_type="decode")]*len(decode_instance_ids))
+    global_scheduler.scale_up(decode_instance_ids, [InstanceType.DECODE]*len(decode_instance_ids))
     global_scheduler.update_instance_infos(decode_instance_infos)
 
 

--- a/tests/unit_test/global_scheduler/test_global_scheduler.py
+++ b/tests/unit_test/global_scheduler/test_global_scheduler.py
@@ -16,7 +16,7 @@ import pytest
 
 from llumnix.internal_config import GlobalSchedulerConfig
 from llumnix.global_scheduler.global_scheduler import GlobalScheduler
-from llumnix.instance_info import InstanceInfo, InstanceLoadCalculator
+from llumnix.instance_info import InstanceInfo, InstanceLoadCalculator, InstanceType
 from llumnix.utils import random_uuid
 from llumnix.instance_info import InstanceType
 
@@ -43,7 +43,74 @@ def global_scheduler():
     global_scheduler = init_global_scheduler()
     yield global_scheduler
 
-def test_scale_up_and_scale_down(global_scheduler):
+def test_add_instance_and_remove_instance(global_scheduler):
+    # test prefill instance
+    global_scheduler.scale_up('instance_1', [InstanceArgs(instance_type="no_constraints")])
+    assert global_scheduler.num_instances == 1
+    assert len(global_scheduler.instance_info) == 1
+    assert len(global_scheduler.instance_id_set) == 1
+    assert len(global_scheduler.available_prefill_instance_info) == 1
+    assert len(global_scheduler.available_decode_instance_info) == 0
+    assert global_scheduler.available_prefill_instance_num_requests['instance_1'] == 0
+    assert global_scheduler.available_decode_instance_num_requests.get("instance_1", None) is None
+    assert 'instance_1' in global_scheduler.instance_id_set
+
+    global_scheduler.scale_down('instance_1')
+    assert global_scheduler.num_instances == 0
+    assert len(global_scheduler.instance_info) == 0
+    assert len(global_scheduler.instance_id_set) == 0
+    assert len(global_scheduler.available_prefill_instance_info) == 0
+    assert len(global_scheduler.available_decode_instance_info) == 0
+    assert global_scheduler.available_prefill_instance_num_requests.get("instance_1", None) is None
+    assert global_scheduler.available_decode_instance_num_requests.get("instance_1", None) is None
+
+
+    global_scheduler.scale_up('instance_2', [InstanceArgs(instance_type="prefill")])
+    assert len(global_scheduler.available_prefill_instance_num_requests) == 1
+    assert global_scheduler.available_prefill_instance_num_requests['instance_2'] == 0
+    assert len(global_scheduler.available_prefill_instance_info) == 1
+    assert len(global_scheduler.instance_id_set) == 1
+    global_scheduler.scale_up('instance_3', [InstanceArgs(instance_type="prefill")])
+    assert len(global_scheduler.available_prefill_instance_num_requests) == 2
+    assert global_scheduler.available_prefill_instance_num_requests['instance_3'] == 0
+    assert len(global_scheduler.available_prefill_instance_info) == 2
+    assert len(global_scheduler.instance_id_set) == 2
+
+
+    global_scheduler.scale_down('instance_2')
+    assert len(global_scheduler.available_prefill_instance_info) == 1
+    assert len(global_scheduler.instance_info) == 1
+    global_scheduler.scale_down('instance_3')
+    assert len(global_scheduler.available_prefill_instance_info) == 0
+    assert len(global_scheduler.instance_info) == 0
+
+    # test decode instance
+    global_scheduler.scale_up('instance_1', [InstanceArgs(instance_type="decode")])
+    assert len(global_scheduler.available_decode_instance_info) == 1
+    assert len(global_scheduler.available_prefill_instance_info) == 0
+    global_scheduler.scale_down('instance_1')
+    assert global_scheduler.num_instances == 0
+    assert len(global_scheduler.available_decode_instance_num_requests) == 0
+    assert len(global_scheduler.instance_info) == 0
+    assert len(global_scheduler.instance_id_set) == 0
+    assert len(global_scheduler.available_prefill_instance_info) == 0
+    assert len(global_scheduler.available_decode_instance_info) == 0
+
+    global_scheduler.scale_up('instance_2', [InstanceArgs(instance_type="decode")])
+    assert len(global_scheduler.available_decode_instance_info) == 1
+    global_scheduler.scale_up('instance_3', [InstanceArgs(instance_type="decode")])
+    assert len(global_scheduler.available_decode_instance_info) == 2
+    assert global_scheduler.num_instances == 2
+    assert len(global_scheduler.available_decode_instance_num_requests) == 2
+    assert len(global_scheduler.available_prefill_instance_num_requests) == 0
+    assert len(global_scheduler.instance_info) == 2
+    assert len(global_scheduler.instance_id_set) == 2
+
+    global_scheduler.scale_down('instance_2')
+    assert len(global_scheduler.instance_id_set) == 1
+    global_scheduler.scale_down('instance_3')
+    assert len(global_scheduler.instance_id_set) == 0
+
     initial_instances = 4
     instance_infos = init_instance_infos(initial_instances)
     instance_ids = [instance_info.instance_id for instance_info in instance_infos]
@@ -74,6 +141,28 @@ def test_dispatch(global_scheduler):
     global_scheduler.update_instance_infos(instance_infos)
     instance_id, request_expected_steps = global_scheduler.dispatch()
     assert instance_id in instance_ids
+    assert request_expected_steps == math.inf
+
+def test_dispatch_decode(global_scheduler):
+    initial_instances = 4
+    prefill_instance_infos = init_instance_infos(initial_instances)
+    prefill_instance_ids = [instance_info.instance_id for instance_info in prefill_instance_infos]
+    global_scheduler.global_scheduler_config.enable_pd_disagg = True
+    global_scheduler.scale_up(prefill_instance_ids, [InstanceArgs(instance_type="prefill")]*len(prefill_instance_ids))
+    global_scheduler.update_instance_infos(prefill_instance_infos)
+
+    decode_instance_infos = init_instance_infos(initial_instances)
+    decode_instance_ids = [instance_info.instance_id for instance_info in decode_instance_infos]
+    global_scheduler.scale_up(decode_instance_ids, [InstanceArgs(instance_type="decode")]*len(decode_instance_ids))
+    global_scheduler.update_instance_infos(decode_instance_infos)
+
+
+    prefill_instance_id, request_expected_steps = global_scheduler.dispatch(InstanceType.PREFILL)
+    assert prefill_instance_id in prefill_instance_ids
+    assert request_expected_steps == 1
+
+    decode_instance_id, request_expected_steps = global_scheduler.dispatch(InstanceType.DECODE)
+    assert decode_instance_id in decode_instance_ids
     assert request_expected_steps == math.inf
 
 def test_pair_migration(global_scheduler):

--- a/tests/unit_test/global_scheduler/test_migration_scheduler.py
+++ b/tests/unit_test/global_scheduler/test_migration_scheduler.py
@@ -20,7 +20,6 @@ from llumnix.global_scheduler.migration_scheduler import MigrationScheduler
 from llumnix.instance_info import InstanceType
 from llumnix.global_scheduler.migration_filter import MigrationInstanceFilter, MigrationFilterConfig
 from llumnix.global_scheduler.migration_policy import PairMigrationConstraints
-from llumnix.arg_utils import InstanceArgs
 
 MIGRATE_OUT_LOAD_THRESHOLD = -3.0
 INSTANCE_NUM = 16
@@ -28,17 +27,6 @@ INSTANCE_NUM = 16
 def init_migration_scheduler(policy='balanced'):
     migration_scheduler = MigrationScheduler(policy, MIGRATE_OUT_LOAD_THRESHOLD, False)
     return migration_scheduler
-
-def test_add_instance_and_remove_instance():
-    migration_scheduler = init_migration_scheduler('balanced')
-    migration_scheduler.add_instance('instance_1', InstanceArgs(instance_type="no_constraints"))
-    assert migration_scheduler.num_instances == 1
-    migration_scheduler.add_instance('instance_2', InstanceArgs(instance_type="no_constraints"))
-    assert migration_scheduler.num_instances == 2
-    migration_scheduler.remove_instance('instance_1')
-    assert migration_scheduler.num_instances == 1
-    migration_scheduler.remove_instance('instance_2')
-    assert migration_scheduler.num_instances == 0
 
 @pytest.mark.parametrize("pair_migration_type", ['NO_CONSTRAINTS', 'DECODE_2_DECODE', 'PREFILL_2_DECODE'])
 def test_migration_filter(pair_migration_type):
@@ -115,7 +103,7 @@ def test_pair_migration(policy):
             instance_info_dict[instance_id] = instance_info
         migration_scheduler.instance_info = instance_info_dict
 
-        migrate_instance_pairs = migration_scheduler.pair_migration(PairMigrationConstraints.NO_CONSTRAINTS)
+        migrate_instance_pairs = migration_scheduler.pair_migration(instance_info_dict, PairMigrationConstraints.NO_CONSTRAINTS)
         exist_migration = exist_migration or len(migrate_instance_pairs) > 0
 
         for migrate_out_instance, migrate_in_instance in migrate_instance_pairs:


### PR DESCRIPTION
1. support dispatch decode instance in manager when using bladellm
2. centralize instance info management into global_scheduler. Make dispatch_scheduler, migration_scheduler and scaling_scheduler focus on scheduling.