### PR TITLE
[PDD][Deployment] Support engine based prefill decode disaggregation in global launch mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ bladellm_unit_test: check_pytest_installed
 
 .PHONY: vllm_offline_test
 vllm_offline_test:
-	@python examlpes/offline_inference.py
+	@python examples/offline_inference.py
 
 # TODO(KuilongCui): add bladellm offine inference example
 

--- a/docs/Arguments.md
+++ b/docs/Arguments.md
@@ -56,6 +56,8 @@ usage: -m llumnix.entrypoints.vllm.api_server [-h]
             [--migration-last-stage-max-blocks MIGRATION_LAST_STAGE_MAX_BLOCKS]
             [--enable-pd-disagg]
             [--pd-ratio PD_RATIO]
+            [--load-registered-service]
+            [--load-registered-service-path]
             [--enable-port-increment]
             [--enable-port-offset-store]
             [--instance-type INSTANCE_TYPE]
@@ -255,8 +257,16 @@ usage: -m llumnix.entrypoints.vllm.api_server [-h]
 - Enable prefill decoding disaggregation.
 
 `--pd-ratio`
-- The p:d ratio used in gloabl launch model.
+- The p:d ratio used in gloabl launch mode.
 - Default: "1:1"
+
+`--load-registered-service`
+- Load registered service.
+- Default: False
+
+`--load-registered-service-path`
+- Path of loading registered service.
+- Default: None
 
 `--enable-port-increment`
 - Enable port increment when desploying multiple servers.

--- a/llumnix/backends/utils.py
+++ b/llumnix/backends/utils.py
@@ -65,8 +65,8 @@ class AsyncPutQueueActor:
                 server_info = server_info_dict[server_id]
                 logger.error("Server {} is dead, exception: {}".format(server_id, ret))
                 if self.request_output_queue_type == QueueType.ZMQ:
-                    logger.warning("request output queue ip: {}, port: {}".format(server_info.request_output_queue_ip,
-                                                                                  server_info.request_output_queue_port))
+                    logger.debug("request output queue ip: {}, port: {}".format(server_info.request_output_queue_ip,
+                                                                                server_info.request_output_queue_port))
                 req_outputs = list(server_request_outputs.values())[idx]
                 request_ids = [req_output.request_id for req_output in req_outputs]
                 self.engine_actor_handle.abort.remote(request_ids)

--- a/llumnix/config/default.py
+++ b/llumnix/config/default.py
@@ -73,8 +73,13 @@ _C.MANAGER.ENABLE_PORT_INCREMENT = False
 _C.MANAGER.ENABLE_PORT_OFFSET_STORE = False
 # Enable prefill decoding disaggregation
 _C.MANAGER.ENABLE_PD_DISAGG = False
-# The p:d ratio used in gloabl launch model
+# The p:d ratio used in gloabl launch mode
 _C.MANAGER.PD_RATIO = "1:1"
+# Load engine arguments from storage
+_C.MANAGER.LOAD_REGISTERED_SERVICE = False
+# Path of loading engine arguments
+_C.MANAGER.LOAD_REGISTERED_SERVICE_PATH = None
+
 
 # -------------------------- DISPATCH CONFIGURATION ---------------------------
 # Request dispatch policy

--- a/llumnix/entrypoints/bladellm/api_server.py
+++ b/llumnix/entrypoints/bladellm/api_server.py
@@ -116,7 +116,7 @@ def get_args(llumnix_cfg, llumnix_parser, engine_args: ServingArgs):
 
     EntrypointsArgs.check_args(entrypoints_args, llumnix_parser)
     instance_args.check_args(instance_args, manager_args, LaunchMode.LOCAL, llumnix_parser)
-    ManagerArgs.check_args(manager_args, llumnix_parser)
+    ManagerArgs.check_args(manager_args, llumnix_parser, LaunchMode.LOCAL)
 
     assert not instance_args.simulator_mode, "Only support the simulator mode for vLLM."
 

--- a/llumnix/entrypoints/vllm/arg_utils.py
+++ b/llumnix/entrypoints/vllm/arg_utils.py
@@ -4,9 +4,10 @@ from vllm.engine.arg_utils import AsyncEngineArgs
 
 from llumnix.logging.logger import init_logger
 from llumnix.backends.backend_interface import BackendType
-from llumnix.backends.vllm.utils import check_engine_args
+from llumnix.backends.vllm.utils import check_engine_args, check_instance_args
 from llumnix.arg_utils import EntrypointsArgs, ManagerArgs, InstanceArgs, LlumnixArgumentParser
 from llumnix.entrypoints.utils import LaunchMode
+from llumnix.utils import load_engine_args
 
 logger = init_logger(__name__)
 
@@ -20,6 +21,12 @@ def add_cli_args(parser: LlumnixArgumentParser) -> LlumnixArgumentParser:
     parser = AsyncEngineArgs.add_cli_args(parser)
     return parser
 
+def add_engine_cli_args(parser: LlumnixArgumentParser) -> "Namespace":
+    parser = AsyncEngineArgs.add_cli_args(parser)
+    cli_args = parser.parse_args()
+
+    return cli_args
+
 def get_args(cfg, launch_mode: LaunchMode, parser: LlumnixArgumentParser, cli_args: "Namespace") \
         -> Tuple[EntrypointsArgs, ManagerArgs, InstanceArgs, AsyncEngineArgs]:
     engine_args = AsyncEngineArgs.from_cli_args(cli_args)
@@ -30,13 +37,32 @@ def get_args(cfg, launch_mode: LaunchMode, parser: LlumnixArgumentParser, cli_ar
     entrypoints_args = EntrypointsArgs.from_llumnix_config(cfg)
 
     EntrypointsArgs.check_args(entrypoints_args, parser)
-    ManagerArgs.check_args(manager_args, parser)
+    ManagerArgs.check_args(manager_args, parser, launch_mode)
     InstanceArgs.check_args(instance_args, manager_args, launch_mode, parser)
-    check_engine_args(engine_args, instance_args)
 
     logger.info("entrypoints_args: {}".format(entrypoints_args))
     logger.info("manager_args: {}".format(manager_args))
     logger.info("instance_args: {}".format(instance_args))
+
+    if manager_args.load_registered_service:
+        if not manager_args.enable_pd_disagg and not manager_args.enable_engine_pd_disagg:
+            instance_type_list = ['no_constraints']
+        else:
+            instance_type_list = ['prefill', 'decode']
+        for instance_type in instance_type_list:
+            engine_args_registered = load_engine_args(instance_type, manager_args.load_registered_service_path)
+            check_instance_args(instance_args, engine_args_registered)
+        return entrypoints_args, manager_args, instance_args, engine_args
+
+    check_engine_args(engine_args)
+    check_instance_args(instance_args, engine_args)
     logger.info("engine_args: {}".format(engine_args))
 
     return entrypoints_args, manager_args, instance_args, engine_args
+
+def get_engine_args(cli_args: "Namespace") -> AsyncEngineArgs:
+    engine_args = AsyncEngineArgs.from_cli_args(cli_args)
+    check_engine_args(engine_args)
+    logger.info("engine_args: {}".format(engine_args))
+
+    return engine_args

--- a/llumnix/entrypoints/vllm/register_service.py
+++ b/llumnix/entrypoints/vllm/register_service.py
@@ -1,0 +1,33 @@
+import argparse
+
+from llumnix.entrypoints.vllm.arg_utils import add_engine_cli_args, get_engine_args
+from llumnix.utils import save_engine_args
+from llumnix.entrypoints.setup import connect_to_ray_cluster
+
+# TODO(s5u13b): Add examples for pdd launch.
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--engine-type',
+                        type=str,
+                        choices=['prefill', 'decode', 'no_constraints'],
+                        default='no_constraints',
+                        help="Engine type of the engine arguments. The actual save filename is generated according to "
+                             "the engine type, following the format f\"engine_args_{engine_type}.pkl\".")
+    parser.add_argument('--save-key',
+                        type=str,
+                        help="Save key of the engine arguments. The actual save filepath is generated according to "
+                             "the save path and save key, following the organization f\"{save_path}/{save_key}/\".")
+    parser.add_argument('--save-path',
+                        type=str,
+                        default='.',
+                        help="Save path of the engine arguments.")
+
+    cli_args = add_engine_cli_args(parser)
+    engine_args = get_engine_args(cli_args)
+
+    connect_to_ray_cluster()
+
+    save_engine_args(cli_args.engine_type, cli_args.save_path, engine_args, cli_args.save_key)

--- a/llumnix/entrypoints/vllm/serve.py
+++ b/llumnix/entrypoints/vllm/serve.py
@@ -24,13 +24,14 @@ if __name__ == "__main__":
     parser = add_cli_args(parser)
     cli_args = parser.parse_args()
     cfg = get_llumnix_config(cli_args.config_file, cli_args)
+
+    # Assume that there is an existing ray cluster when using centralized deployment.
+    connect_to_ray_cluster()
+
     entrypoints_args, manager_args, instance_args, engine_args = get_args(cfg, LaunchMode.GLOBAL, parser, cli_args)
 
     backend_type = BackendType.VLLM if not instance_args.simulator_mode else BackendType.SIM_VLLM
     launch_args = LaunchArgs(launch_mode=LaunchMode.GLOBAL, backend_type=backend_type)
-
-    # Assume that there is an existing ray cluster when using centralized deployment.
-    connect_to_ray_cluster()
 
     # magic actor to avoid fast api server actor initialization error
     request_output_queue = RayQueue(actor_options={"namespace": "llumnix",

--- a/llumnix/global_scheduler/migration_filter.py
+++ b/llumnix/global_scheduler/migration_filter.py
@@ -91,7 +91,7 @@ class LoadFilter(MigrationFilterPolicy):
             and instance_info.migration_load_metric < filter_config.migrate_out_load_threshold
 
 
-class PddFilter(MigrationFilterPolicy):
+class PDDFilter(MigrationFilterPolicy):
     INSTANCE_FILTER_RULES = {
         PairMigrationConstraints.DECODING_2_DECODING: (InstanceType.DECODE, InstanceType.DECODE),
         PairMigrationConstraints.PREFILL_2_DECODING: (InstanceType.PREFILL, InstanceType.DECODE),
@@ -149,7 +149,7 @@ class CustomFilter(MigrationFilterPolicy):
 class MigrationFilterPolicyFactory:
     _POLICY_REGISTRY = {
         'load': LoadFilter,
-        'pdd': PddFilter,
+        'pdd': PDDFilter,
         'custom': CustomFilter,
     }
 

--- a/llumnix/internal_config.py
+++ b/llumnix/internal_config.py
@@ -11,6 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Union, List
+
+
 class GlobalSchedulerConfig:
     def __init__(
             self,
@@ -65,3 +68,14 @@ class MigrationConfig:
         self.migration_backend_init_timeout = migration_backend_init_timeout
         self.grpc_migration_backend_server_port = grpc_migration_backend_server_port
         self.kvtransfer_migration_backend_naming_url = kvtransfer_migration_backend_naming_url
+
+
+class PDDConfig:
+    def __init__(
+        self,
+        enable_pd_disagg: bool,
+        enable_engine_pd_disagg: bool,
+        pd_ratio: Union[str, List[int]]) -> None:
+        self.enable_pd_disagg = enable_pd_disagg
+        self.enable_engine_pd_disagg = enable_engine_pd_disagg
+        self.pd_ratio = pd_ratio

--- a/llumnix/manager.py
+++ b/llumnix/manager.py
@@ -104,12 +104,13 @@ class Manager:
         self.polling_interval = manager_args.polling_interval
 
         self.is_group_kind_migration_backend = manager_args.is_group_kind_migration_backend
-        global_scheduler_config = manager_args.create_global_scheduler_config(self.is_group_kind_migration_backend)
+        global_scheduler_config = manager_args.create_global_scheduler_config()
         self.global_scheduler = GlobalScheduler(global_scheduler_config)
 
+        pdd_config = manager_args.create_pdd_config()
         self.launcher: Launcher = Launcher(self.global_scheduler, manager_args.enable_port_increment,
-                                           manager_args.enable_port_offset_store, manager_args.enable_pd_disagg,
-                                           manager_args.enable_engine_pd_disagg, manager_args.pd_ratio)
+                                           manager_args.enable_port_offset_store, manager_args.load_registered_service,
+                                           manager_args.load_registered_service_path, pdd_config)
 
         # log args
         self.log_requests = not manager_args.disable_log_requests_manager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,8 +48,8 @@ def cleanup_ray_env_func():
         try:
             actor_handle = ray.get_actor(actor_info['name'], namespace=actor_info['namespace'])
             ray.kill(actor_handle)
-        # pylint: disable=broad-except, unused-variable
-        except Exception as e:
+        # pylint: disable=bare-except
+        except:
             pass
 
     time.sleep(1.0)
@@ -59,9 +59,9 @@ def cleanup_ray_env_func():
         try:
             pg = PlacementGroup(PlacementGroupID(hex_to_binary(placement_group_id)) )
             remove_placement_group(pg)
-        # pylint: disable=broad-except
-        except Exception as e:
-            print("clear placement group error: ", e)
+        # pylint: disable=bare-except
+        except:
+            pass
 
     time.sleep(1.0)
 

--- a/tests/e2e_test/test_bench.py
+++ b/tests/e2e_test/test_bench.py
@@ -30,6 +30,8 @@ from .utils import (generate_vllm_launch_command, generate_bench_command, to_mar
 
 BENCH_TEST_TIMEOUT_MINS = 60
 
+# TODO(s5u13b): Reorganize the bench test to make codes cleaner.
+
 
 def parse_log_file(title: str):
     json_files = [f for f in os.listdir('.') if f.endswith('_latency_info.json')]
@@ -76,10 +78,10 @@ def parse_log_file(title: str):
 @pytest.mark.parametrize("launch_mode", ['global', 'local'])
 @pytest.mark.parametrize("enable_pd_disagg", [True, False])
 @pytest.mark.parametrize("enable_simulator", [False, True])
-@pytest.mark.parametrize("engine", ["engine_vLLM", "engine_BladeLLM"])
 @pytest.mark.parametrize("request_output_queue_type", ["rayqueue", "zmq"])
+@pytest.mark.parametrize("engine", ["engine_vLLM", "engine_BladeLLM"])
 async def test_simple_benchmark(ray_env, shutdown_llumnix_service, enable_simulator,
-                                model, launch_mode, enable_pd_disagg, engine, request_output_queue_type):
+                                model, launch_mode, enable_pd_disagg, request_output_queue_type, engine):
     engine = engine.split("_")[1]
 
     if "BladeLLM" in engine and launch_mode == "global":

--- a/tests/e2e_test/test_migration.py
+++ b/tests/e2e_test/test_migration.py
@@ -114,6 +114,9 @@ async def test_migration_benchmark(ray_env, shutdown_llumnix_service, model, ten
     if migration_request_status == 'waiting' and migration_backend != 'rayrpc':
         pytest.skip("When the migrated request status is waiting, only test the rayrpc migration backend.")
 
+    if tensor_parallel_size == 2 and migration_backend == 'nccl':
+        pytest.skip("When the migration backend is nccl, tensor parallelism is not supported.")
+
     request_migration_policy = 'SR' if migration_request_status == 'running' else 'FCW'
     ip = get_ip_address()
     base_port = 37037

--- a/tests/e2e_test/utils.py
+++ b/tests/e2e_test/utils.py
@@ -71,7 +71,8 @@ def generate_vllm_launch_command(
         f"--instance-type {instance_type} "
         f"--max-num-batched-tokens {max_num_batched_tokens} "
         f"{'--simulator-mode ' if enable_simulator else ''}"
-        f"{'--profiling-result-file-path /mnt/model/simulator/Qwen-7B.pkl' if enable_simulator else ''}"
+        f"{'--profiling-result-file-path /mnt/model/simulator/Qwen-7B.pkl ' if enable_simulator else ''}"
+        f"{'--disable-async-output-proc ' if enable_simulator else ''}"
         f"{'> instance_'+result_filename if len(result_filename)> 0 else ''} 2>&1 &"
     )
     return command
@@ -122,7 +123,8 @@ def generate_vllm_serve_command(
         f"{'--simulator-mode ' if enable_simulator else ''}"
         f"--config-file {config_path} "
         f"--max-instances 4 "
-        f"{'--profiling-result-file-path /mnt/model/simulator/Qwen-7B.pkl' if enable_simulator else ''}"
+        f"{'--profiling-result-file-path /mnt/model/simulator/Qwen-7B.pkl ' if enable_simulator else ''}"
+        f"{'--disable-async-output-proc ' if enable_simulator else ''}"
         f"{'> instance_'+result_filename if len(result_filename)> 0 else ''} 2>&1 &"
     )
     return command

--- a/tests/unit_test/entrypoints/vllm/api_server_actor.py
+++ b/tests/unit_test/entrypoints/vllm/api_server_actor.py
@@ -37,7 +37,7 @@ class MockManagerServer(MockManager):
 
     def init_server(self, entrypoints_args):
         server = APIServerActor.options(name=ENTRYPOINTS_ACTOR_NAME,
-                                       namespace='llumnix').remote(entrypoints_args)
+                                        namespace='llumnix').remote(entrypoints_args)
         return server
 
     # pylint: disable=arguments-renamed

--- a/tests/unit_test/test_utils.py
+++ b/tests/unit_test/test_utils.py
@@ -1,0 +1,25 @@
+import os
+import pytest
+
+from vllm import EngineArgs
+
+from llumnix.utils import (save_engine_args, load_engine_args, _get_engine_args_filename,
+                           _get_engine_args_filepath)
+
+# pylint: disable=unused-import
+from tests.conftest import ray_env
+
+
+@pytest.mark.parametrize("save_key", [None, "test"])
+def test_save_engine_args_and_load_engine_args(ray_env, save_key):
+    engine_args = EngineArgs()
+    engine_type = "no_constraints"
+    save_path = "."
+    save_engine_args(engine_type, save_path, engine_args, save_key)
+    final_save_path = _get_engine_args_filepath(save_path, save_key)
+    engine_args_load = load_engine_args(engine_type, final_save_path)
+    assert engine_args_load == engine_args
+    engine_args_filename = _get_engine_args_filename(engine_type)
+    save_filename = os.path.join(final_save_path, engine_args_filename)
+    assert os.path.exists(save_filename)
+    os.remove(save_filename)


### PR DESCRIPTION
For engine based prefill decode disaggregation in global launch mode, after this pr, user can first run register_args.py twice to register engine args for prefill and decode type engine, and then user can run serve.py to launch based prefill decode disaggregation in global launch mode.
Test command
```bash
python llumnix/entrypoints/vllm/save_engine_args.py --engine-type prefill --save-path test --save-key test --worker-use-ray
python llumnix/entrypoints/vllm/save_engine_args.py --engine-type decode --save-path test --save-key test --worker-use-ray
python llumnix/entrypoints/vllm/serve.py --enable-pd-disagg --worker-use-ray --load-engine-args-from-storage --load-engine-args-path ./test/test
```
