### PR TITLE
[Deployment] Support eas deploy

### DIFF
--- a/llumnix/entrypoints/api_server_actor.py
+++ b/llumnix/entrypoints/api_server_actor.py
@@ -25,7 +25,10 @@ class APIServerActor(ABC):
         logger.info("APIServerActor(job_id={}, worker_id={}, actor_id={}, node_id={}, instance_id={})".format(
                         self.job_id, self.worker_id, self.actor_id, self.node_id, self.instance_id))
         self.entrypoints_args = entrypoints_args
-        self.host = get_ip_address()
+        if entrypoints_args.host in ("127.0.0.1", "0.0.0.0"):
+            self.host = entrypoints_args.host
+        else:
+            self.host = get_ip_address()
         self.request_output_queue_port = self.entrypoints_args.request_output_queue_port
         self.request_output_queue_type = QueueType(self.entrypoints_args.request_output_queue_type)
         self.request_output_queue = init_request_output_queue_server(

--- a/llumnix/entrypoints/bladellm/api_server_actor.py
+++ b/llumnix/entrypoints/bladellm/api_server_actor.py
@@ -20,6 +20,7 @@ class APIServerActorBladeLLM(APIServerActor):
         from llumnix.entrypoints.bladellm.client import LlumnixClientBladeLLM
         # bladellm engine_args is dumped by pickle
         engine_args = pickle.loads(entrypoints_args.engine_args)
+        engine_args.host = self.host
         loop = asyncio.new_event_loop()
         llumnix_client = LlumnixClientBladeLLM(engine_args, entrypoints_context, loop)
         web_app = LlumnixEntrypoint(client=llumnix_client, args=engine_args).create_web_app()


### PR DESCRIPTION
If host in launch parameter is '127.0.0.1' or '0.0.0.0', llumnix will not use local ip as entrypoint host.