### PR TITLE
[Misc] Specify the version of aiohttp to ensure compatibility with BladeLLM

### DIFF
--- a/requirements/requirements_bladellm.txt
+++ b/requirements/requirements_bladellm.txt
@@ -1,6 +1,7 @@
 ray[default]
 pyarrow  # Required for Ray data.
-aiohttp
+aiohttp == 3.8.4
+aiohttp-cors == 0.7.0
 pandas
 matplotlib
 pyyaml


### PR DESCRIPTION
Limit version of some pip packages
1. aiohttp == 3.8.4
2. aiohttp-cors == 0.7.0
aiohttp 3.11.x will cause bladellm engine return incorrect response format