### PR TITLE
[Bugfix] Fix BladeLLM migration bug in req_tracker

### DIFF
--- a/llumnix/backends/bladellm/llm_engine.py
+++ b/llumnix/backends/bladellm/llm_engine.py
@@ -514,6 +514,7 @@ class BackendBladeLLM(BackendInterface):
 
     def add_running_request(self, backend_request: GenerationGroupStateLlumnix) -> None:
         self.engine.trans_wrapper.add_request(backend_request.request_id, backend_request.server_info)
+        self.engine._req_tracker.req_metrics_map[backend_request.request_id] = backend_request.req_metrics
         return self.engine.scheduler.add_running_request(backend_request)
 
     def free_dst_pre_alloc_cache(self, *args, **kwargs) -> None:


### PR DESCRIPTION
In the final phase of the migration, in the previous implementation, if an ABORTED_DST occurred, the req_tracker state of the request was mistakenly left unrestored in the add_running_request function.