### PR TITLE
[Bugfix] Fix token failing to return to API server during drop, abort, or migration

### DIFF
--- a/llumnix/backends/bladellm/llm_engine.py
+++ b/llumnix/backends/bladellm/llm_engine.py
@@ -108,7 +108,7 @@ class AsyncBackQueueWrapper:
         MAX_ITEMS_PER_PROCEDURE: int = 1000 # pylint: disable=invalid-name
 
         while True:
-            cur_step_idx: int = self.get_current_step_counter_queue.get()
+            cur_step_idx: int = await self.get_current_step_counter_queue.get()
             self.backup_dangling_request_server_info.update(self.dangling_request_server_info)
             self.dangling_request_server_info = {}
 

--- a/llumnix/backends/bladellm/llm_engine.py
+++ b/llumnix/backends/bladellm/llm_engine.py
@@ -105,7 +105,7 @@ class AsyncBackQueueWrapper:
         asyncio.create_task(self._clear_request_server_info_loop())
 
     async def _clear_request_server_info_loop(self):
-        MAX_ITEMS_PER_PROCEDURE: int = 1000
+        MAX_ITEMS_PER_PROCEDURE: int = 1000 # pylint: disable=invalid-name
 
         while True:
             cur_step_idx: int = self.get_current_step_counter_queue.get()
@@ -119,7 +119,6 @@ class AsyncBackQueueWrapper:
 
                 if loop_idx % MAX_ITEMS_PER_PROCEDURE == 0:
                     await asyncio.sleep(0)
-            
 
     async def _put_request_outputs_loop(self):
         async def get_single_response() -> Tuple[GenerateStreamResponse, ServerInfo]:

--- a/llumnix/backends/bladellm/llm_engine.py
+++ b/llumnix/backends/bladellm/llm_engine.py
@@ -602,7 +602,7 @@ class BackendBladeLLM(BackendInterface):
         return self.engine.scheduler.free_dst_pre_alloc_cache(*args, **kwargs)
 
     def free_src_request(self, backend_request: LlumnixRequest) -> None:
-        expired_step = self.engine.step_counter + self.engine.max_async_step
+        expired_step = self.engine.step_counter + self.engine.max_async_step + 1
         self.engine.trans_wrapper.remove_request_server_info(backend_request.request_id, expired_step)
         return self.engine.scheduler.free_src_request(backend_request)
 

--- a/llumnix/backends/bladellm/metrics.py
+++ b/llumnix/backends/bladellm/metrics.py
@@ -52,8 +52,6 @@ class BladeLLMMetrics(LlumnixMetrics):
         self.num_blocks_first_waiting_request.observe(scheduler.get_num_blocks_first_waiting_request())
         self.num_blocks_last_running_request.observe(scheduler.get_num_blocks_last_running_request())
         self.all_request_ids.observe(scheduler.get_all_request_ids())
-        if self.dump_step % 100 == 0:
-            self.dump()
 
     def engine_step_metrics(self, scheduler):
         block_manager: BlockSpaceManager = scheduler.block_manager

--- a/llumnix/backends/bladellm/scheduler.py
+++ b/llumnix/backends/bladellm/scheduler.py
@@ -48,9 +48,6 @@ class PagedSchedulerLlumnix(PagedScheduler):
         self.trans_wrapper: AsyncBackQueueWrapper = None
         self.step_counter: int = 0
 
-    def set_max_async_step(self, max_async_step: int):
-        self.max_async_step = max_async_step
-
     def pipeline_running_filter(self, batches: Union[List[int], List[GenerationGroupState]]):
         batches = super().pipeline_running_filter(batches)
         if not batches:
@@ -99,7 +96,7 @@ class PagedSchedulerLlumnix(PagedScheduler):
 
     def drop_request(self, req_id: int):
         self.id2group[req_id]._status = RequestStatus.FINISHED
-        self.trans_wrapper.remove_request_server_info(req_id, self.step_counter + self.max_async_step)
+        self.trans_wrapper.remove_request_server_info(req_id, self.step_counter)
         super().drop_request(req_id)
 
     # happends when moving request from waiting to running


### PR DESCRIPTION
Due to Bladellm returning tokens to Llumnix asynchronously, Llumnix cannot directly delete the server-related information for a request in the request_server_map during handle_abort, handle_drop, or migration free_src_request. Instead, the related information can only be safely removed after the corresponding step's output token has been actually processed in the AsyncBackQueueWrapper.