### PR TITLE
[vLLM-v1] Support data parallel of vLLM v1 with DPManager

### DIFF
--- a/llumnix/backends/utils.py
+++ b/llumnix/backends/utils.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
+from typing import Any, Optional
 import os
 from enum import Enum
 
@@ -22,7 +22,7 @@ from llumnix.arg_utils import LlumnixEngineArgs, InstanceArgs
 from llumnix.backends.backend_interface import BackendInterface
 from llumnix.queue.queue_type import QueueType
 from llumnix.logging.logger import init_logger
-from llumnix.utils import BackendType
+from llumnix.utils import (BackendType, ray_get_with_timeout)
 
 
 logger = init_logger(__name__)
@@ -60,7 +60,9 @@ def init_backend_engine(instance_id: str,
                         placement_group: PlacementGroup,
                         request_output_queue_type: QueueType,
                         instance_args: InstanceArgs,
-                        llumnix_engine_args: LlumnixEngineArgs) -> BackendInterface:
+                        llumnix_engine_args: LlumnixEngineArgs,
+                        dp_rank: int = 0,
+                        dp_rank_local: Optional[int] = None) -> BackendInterface:
     backend_type = llumnix_engine_args.backend_type
     if backend_type == BackendType.VLLM:
         # pylint: disable=import-outside-toplevel
@@ -77,7 +79,8 @@ def init_backend_engine(instance_id: str,
                                      placement_group,
                                      request_output_queue_type,
                                      instance_args,
-                                     llumnix_engine_args)
+                                     llumnix_engine_args,
+                                     dp_rank, dp_rank_local)
     elif backend_type == BackendType.BLADELLM:
         # pylint: disable=import-outside-toplevel
         from llumnix.backends.bladellm.llm_engine import BackendBladeLLM

--- a/llumnix/constants.py
+++ b/llumnix/constants.py
@@ -42,6 +42,7 @@ CHECK_DEPLOYMENT_STATES_INTERVAL: float = 30.0
 WATCH_DEPLOYMENT_INTERVAL: float = 10.0
 INSTANCE_READY_TIMEOUT: float = 300.0
 SERVER_READY_TIMEOUT: float = 30.0
+DPMANAGER_INIT_TIMEOUT: float = 300.0
 
 # llumnix/global_scheduler/dispatch_scheduler.py
 DISPATCH_LOG_FREQUENCY: int = 100
@@ -96,7 +97,7 @@ RAYRPC_MIGRATION_TIMEOUT = 100.0
 # llumnix/entrypoints/api_server_actor.py
 SERVER_GRACEFUL_SHUTDOWN_TIMEOUT: float = 10.0
 # NOTE(shejiarui): vLLM V1 need more time to start server.
-SERVER_START_TIMEOUT: float = 30.0
+SERVER_START_TIMEOUT: float = 240.0
 SERVER_STOP_TIMEOUT: float = 10.0
 
 # llumnix/llumlet/migration_coordinator.py

--- a/llumnix/entrypoints/api_server_actor.py
+++ b/llumnix/entrypoints/api_server_actor.py
@@ -132,7 +132,8 @@ class APIServerActor(ABC):
                   engine_args,
                   scaler: ray.actor.ActorHandle,
                   manager: ray.actor.ActorHandle,
-                  instance: ray.actor.ActorHandle):
+                  instance: ray.actor.ActorHandle,
+                  bundle_index: int = 0):
         api_server_class = ray.remote(
             num_cpus=1,
             num_gpus=num_gpus,
@@ -142,7 +143,7 @@ class APIServerActor(ABC):
         )(cls).options(
             scheduling_strategy=PlacementGroupSchedulingStrategy(
                 placement_group=placement_group,
-                placement_group_bundle_index=0,
+                placement_group_bundle_index=bundle_index,
                 placement_group_capture_child_tasks=True
             )
         )

--- a/llumnix/entrypoints/vllm_v1/arg_utils.py
+++ b/llumnix/entrypoints/vllm_v1/arg_utils.py
@@ -61,6 +61,7 @@ class VLLMV1EngineArgs(LlumnixEngineArgs):
                  engine_args: "AsyncEngineArgs",
                  backend_type: BackendType = BackendType.VLLM_V1) -> None:
         self.world_size = self._get_world_size(engine_args)
+        self.dp_size = self._get_dp_size(engine_args)
         super().__init__(
             engine_args=self._get_engine_args(engine_args),
             backend_type=backend_type
@@ -73,6 +74,10 @@ class VLLMV1EngineArgs(LlumnixEngineArgs):
     def _get_world_size(self, engine_args: "AsyncEngineArgs"):
         world_size = engine_args.pipeline_parallel_size * engine_args.tensor_parallel_size
         return world_size
+
+    def _get_dp_size(self, engine_args: "AsyncEngineArgs"):
+        dp_size = engine_args.data_parallel_size
+        return dp_size
 
     def _get_engine_args(self, engine_args: "AsyncEngineArgs"):
         return pickle.dumps(engine_args)
@@ -89,6 +94,9 @@ class VLLMV1EngineArgs(LlumnixEngineArgs):
 
     def get_world_size(self):
         return self.world_size
+
+    def get_dp_size(self):
+        return self.dp_size
 
 
 @dataclass

--- a/llumnix/entrypoints/vllm_v1/dp_manager.py
+++ b/llumnix/entrypoints/vllm_v1/dp_manager.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2024, Alibaba Group;
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+import ray
+import ray.actor
+from ray.util.placement_group import PlacementGroup
+from ray.util.state import list_actors
+
+from llumnix.logging.logger import init_logger
+from llumnix.arg_utils import (
+    EntrypointsArgs,
+    InstanceArgs,
+    LlumnixEngineArgs,
+)
+from llumnix.llumlet.llumlet import Llumlet
+from llumnix.ray_utils import get_scaler_name, get_manager_name, get_dpmanager_name
+from llumnix.queue.queue_type import QueueType
+from llumnix.entrypoints.vllm_v1.api_server_actor import APIServerActorVLLMV1
+from llumnix.constants import NUM_GPUS_VLLM_V1_GPU_ACTOR
+
+logger = init_logger(__name__)
+
+
+class DPManager:
+    def __init__(self,
+                 instance_id: str,
+                 new_instance_ids: List[str],
+                 entrypoints_args: EntrypointsArgs,
+                 instance_args: InstanceArgs,
+                 engine_args: LlumnixEngineArgs,
+                 placement_group: PlacementGroup):
+        self.instance_id = instance_id
+        self.entrypoints_args = entrypoints_args
+        self.instance_args = instance_args
+        self.placement_group = placement_group
+        self.engine_args = engine_args
+        self.dp_size = engine_args.get_dp_size()
+
+        self.scaler = ray.get_actor(get_scaler_name(), namespace="llumnix")
+        self.manager = ray.get_actor(get_manager_name(), namespace="llumnix")
+
+        self.port_offset = 0
+        self.client_index_offset = 0
+
+        self.instance_ids = new_instance_ids
+        self.instances: List[ray.actor.ActorHandle] = []
+        self.servers: List[ray.actor.ActorHandle] = []
+
+        instance_filter = [("class_name", "=", "Llumlet"), ("placement_group_id", "=", str(placement_group.id))]
+        server_filter = [("class_name", "=", "APIServerActor"), ("placement_group_id", "=", str(placement_group.id))]
+        try:
+            # Try to find instances and servers with class name and placement group
+            # in case that the dp_manager is restarted.
+            instance_actors = list_actors(filters=instance_filter)
+            server_actors = list_actors(filters=server_filter)
+            found_instances = len(instance_actors)
+            found_servers = len(server_actors)
+
+            if found_instances == 0 and found_servers == 0:
+                # No instances or servers found, create them
+                self._init_instances_and_servers()
+            elif found_instances == self.dp_size and found_servers == self.dp_size:
+                for actor in instance_actors:
+                    self.instances.append(ray.get_actor(actor.actor_id))
+                for actor in server_actors:
+                    self.servers.append(ray.get_actor(actor.actor_id))
+            else:
+                raise(RuntimeError("DPManager restarted but found not exactly dp_size instances and servers. "
+                                   "Restart the whole DP group."))
+
+            ray.get([server.is_ready.remote() for server in self.servers])
+            ray.get([instance.is_ready.remote() for instance in self.instances])
+            self.manager.scale_up.remote(self.instance_ids, self.instances, [None] * self.dp_size)
+        # pylint: disable=broad-except
+        except Exception as e:
+            # TODO(shejiarui): scale down if dp_manager restart failed.
+            logger.exception(e)
+
+    @classmethod
+    def from_args(cls,
+                  instance_id: str,
+                  new_instance_ids: List[str],
+                  entrypoints_args: EntrypointsArgs,
+                  instance_args: InstanceArgs,
+                  engine_args: LlumnixEngineArgs,
+                  placement_group: PlacementGroup,
+                  ) -> "DPManager":
+        dp_manager_class = ray.remote(
+            num_cpus=1,
+            name=get_dpmanager_name(instance_id),
+            namespace="llumnix",
+        )(cls)
+        dp_manager = dp_manager_class.remote(
+            instance_id,
+            new_instance_ids,
+            entrypoints_args,
+            instance_args,
+            engine_args,
+            placement_group,
+        )
+        return dp_manager
+
+    def _init_instances_and_servers(self) -> None:
+        request_output_queue_type = QueueType(self.entrypoints_args.request_output_queue_type)
+        # NOTE(shejiarui): noqa for kvt
+        dp_rank_local = 0
+
+        for rank in range(self.dp_size):
+            new_instance_id = self.instance_ids[rank]
+
+            instance = Llumlet.from_args(
+                new_instance_id,
+                self.instance_args,
+                self.placement_group,
+                request_output_queue_type,
+                self.engine_args,
+                dp_rank=rank,
+                dp_rank_local=dp_rank_local,
+            )
+            self.instances.append(instance)
+
+            self.entrypoints_args.port += self.port_offset
+            self.entrypoints_args.client_index += self.client_index_offset
+            self.port_offset += 1
+            self.client_index_offset += 1
+            server = APIServerActorVLLMV1.from_args(
+                NUM_GPUS_VLLM_V1_GPU_ACTOR,
+                new_instance_id,
+                self.placement_group,
+                self.entrypoints_args,
+                self.engine_args,
+                self.scaler,
+                self.manager,
+                instance,
+                bundle_index=rank
+            )
+            self.servers.append(server)

--- a/llumnix/entrypoints/vllm_v1/dp_manager.py
+++ b/llumnix/entrypoints/vllm_v1/dp_manager.py
@@ -140,6 +140,7 @@ class DPManager:
                 new_instance_id,
                 self.placement_group,
                 self.entrypoints_args,
+                self.instance_args,
                 self.engine_args,
                 self.scaler,
                 self.manager,

--- a/llumnix/request_output.py
+++ b/llumnix/request_output.py
@@ -14,7 +14,6 @@
 from typing import Any, Dict
 import copy
 
-from llumnix.metrics.timestamps import RequestTimestamps
 from llumnix.request_processing_context import RequestProcessingContext
 from llumnix.utils import RequestIDType
 
@@ -37,7 +36,12 @@ class LlumnixRequestOuput:
 class LlumnixRequestOutputs:
     """Wrapper of vLLM v1 EngineCoreOutputs"""
     def __init__(self, instance_id: str, engine_outputs: Any,
-                 request_timestamps_dict: Dict[RequestIDType, RequestTimestamps] = None):
+                 request_processing_context_dict: Dict[RequestIDType, RequestProcessingContext] = None):
         self.instance_id = instance_id
         self.engine_outputs = engine_outputs
-        self.request_timestamps_dict = request_timestamps_dict
+        self.request_processing_context_dict: Dict[RequestIDType, RequestProcessingContext] = request_processing_context_dict
+        for request_id, context in self.request_processing_context_dict.items():
+            if context.request_output_queue is not None:
+                new_context = copy.copy(context)
+                new_context.request_output_queue = None
+                self.request_processing_context_dict[request_id] = new_context


### PR DESCRIPTION
Add support of vLLM v1 data parallel serving. Main changes include:
1. Add DPManager component for DP group launching. DPManager will be constructed in Scaler `_auto_scale_up_loop` function.
2. Add AsyncDPEngineCoreProcLlumnix for engine and LlumnixDPClientVLLMV1 for client.

Currently the serving is supported, but fault-tolerant not fully supported yet.