### PR TITLE
[Bugfix][vLLM-v1] Fix TP>1 GPU allocation bug in Executor; Fix OutputForwarder bundle_index bug; Add support for speculative decoding

### DIFF
--- a/llumnix/backends/output_forwarder.py
+++ b/llumnix/backends/output_forwarder.py
@@ -210,6 +210,7 @@ class OutputForwarder:
                  abort_request_callback: Coroutine,
                  placement_group: PlacementGroup,
                  backend_type: BackendType,
+                 bundle_index: int = 0,
                  ):
         self.request_output_queue_type = request_output_queue_type
         self.request_output_forwarding_mode = request_output_forwarding_mode
@@ -218,7 +219,7 @@ class OutputForwarder:
             # Place the actor forwarder together with the instance.
             scheduling_strategy = PlacementGroupSchedulingStrategy(
                 placement_group=placement_group,
-                placement_group_bundle_index=0,
+                placement_group_bundle_index=bundle_index,
                 placement_group_capture_child_tasks=True,
             )
             num_gpus = NUM_GPUS_BLADELLM_GPU_ACTOR if backend_type == BackendType.BLADELLM else 0

--- a/llumnix/backends/vllm_v1/core.py
+++ b/llumnix/backends/vllm_v1/core.py
@@ -123,8 +123,9 @@ class AsyncEngineCoreProcLlumnix(AsyncEngineCoreProc):
         """Creates an EngineCoreProc from the engine arguments."""
         # FIXME(zhaozhiyu): This is a bug of pai-vllm, engine_args.speculative_config
         # must be set to None before calling engine_args.create_engine_config()
-        if hasattr(engine_args, "speculative_config") and engine_args.speculative_config == {}:
-            engine_args.speculative_config = None
+        if hasattr(engine_args, "speculative_config") and engine_args.speculative_config is not None:
+            if len(engine_args.speculative_config) == 0:
+                engine_args.speculative_config = None
         # Create the engine configs.
         engine_config = engine_args.create_engine_config()
         # Hack to pass placement_group for init workers.
@@ -332,8 +333,9 @@ class AsyncDPEngineCoreProcLlumnix(AsyncDPEngineCoreProc, AsyncEngineCoreProcLlu
         dp_rank_local: Optional[int] = None,
     ) -> "AsyncDPEngineCoreProcLlumnix":
         """Creates an DPEngineCoreProc from the engine arguments."""
-        if hasattr(engine_args, "speculative_config") and engine_args.speculative_config == {}:
-            engine_args.speculative_config = None
+        if hasattr(engine_args, "speculative_config") and engine_args.speculative_config is not None:
+            if len(engine_args.speculative_config) == 0:
+                engine_args.speculative_config = None
         # Create the engine configs.
         engine_config = engine_args.create_engine_config()
         engine_config.parallel_config.data_parallel_master_port = vllm_envs.VLLM_DP_MASTER_PORT

--- a/llumnix/backends/vllm_v1/core.py
+++ b/llumnix/backends/vllm_v1/core.py
@@ -78,7 +78,8 @@ class AsyncEngineCoreProcLlumnix(AsyncEngineCoreProc):
                  handshake_address: str,
                  executor_class: type[Executor],
                  log_stats: bool,
-                 engine_index: int = 0) -> None:
+                 engine_index: int = 0,
+                 dp_rank: int = 0) -> None:
 
         # Change EngineCore.scheduler to SchedulerLlumnix
         vllm_config.scheduler_config.scheduler_cls = SchedulerLlumnix
@@ -94,6 +95,7 @@ class AsyncEngineCoreProcLlumnix(AsyncEngineCoreProc):
             abort_request_callback,
             placement_group,
             backend_type,
+            dp_rank,
         )
 
         self.scheduler.add_update_instance_info_callback(self.update_instance_info)
@@ -367,6 +369,7 @@ class AsyncDPEngineCoreProcLlumnix(AsyncDPEngineCoreProc, AsyncEngineCoreProcLlu
             handshake_address=None,
             executor_class=executor_class,
             log_stats=not engine_args.disable_log_stats,
+            dp_rank=dp_rank,
         )
         return engine
 

--- a/llumnix/backends/vllm_v1/core.py
+++ b/llumnix/backends/vllm_v1/core.py
@@ -121,7 +121,7 @@ class AsyncEngineCoreProcLlumnix(AsyncEngineCoreProc):
         """Creates an EngineCoreProc from the engine arguments."""
         # FIXME(zhaozhiyu): This is a bug of pai-vllm, engine_args.speculative_config
         # must be set to None before calling engine_args.create_engine_config()
-        if hasattr(engine_args, "speculative_config"):
+        if hasattr(engine_args, "speculative_config") and engine_args.speculative_config == {}:
             engine_args.speculative_config = None
         # Create the engine configs.
         engine_config = engine_args.create_engine_config()
@@ -330,7 +330,8 @@ class AsyncDPEngineCoreProcLlumnix(AsyncDPEngineCoreProc, AsyncEngineCoreProcLlu
         dp_rank_local: Optional[int] = None,
     ) -> "AsyncDPEngineCoreProcLlumnix":
         """Creates an DPEngineCoreProc from the engine arguments."""
-        engine_args.speculative_config = None
+        if hasattr(engine_args, "speculative_config") and engine_args.speculative_config == {}:
+            engine_args.speculative_config = None
         # Create the engine configs.
         engine_config = engine_args.create_engine_config()
         engine_config.parallel_config.data_parallel_master_port = vllm_envs.VLLM_DP_MASTER_PORT
@@ -551,7 +552,10 @@ class BackendVLLMV1(BackendInterface):
         return self.engine.instance_info
 
     def get_engine_context(self):
-        kvt_engine_available_port = self.engine.vllm_config.kv_transfer_config.engine_available_port
+        kvt_engine_available_port = None
+        if self.engine.vllm_config.kv_transfer_config is not None:
+            kvt_engine_available_port = self.engine.vllm_config.kv_transfer_config.engine_available_port
+
         return InstanceContext(
             local_engine_id=self.instance_id,
             kvt_engine_available_port=kvt_engine_available_port,

--- a/llumnix/backends/vllm_v1/executor.py
+++ b/llumnix/backends/vllm_v1/executor.py
@@ -94,7 +94,6 @@ class LlumnixRayDistributedExecutor(RayDistributedExecutor):
         world_size = self.parallel_config.world_size
         worker_metadata: list[RayWorkerMetaData] = []
         driver_ip = get_ip()
-        num_gpus = 1
 
         if self.parallel_config.data_parallel_size == 1:
             bundle_indices: list[int]
@@ -123,6 +122,7 @@ class LlumnixRayDistributedExecutor(RayDistributedExecutor):
                     placement_group_capture_child_tasks=True,
                     placement_group_bundle_index=bundle_id,
                 )
+                num_gpus = 1
                 if rank == 0:
                     num_gpus = NUM_GPUS_VLLM_V1_GPU_ACTOR
                 if current_platform.ray_device_key == "GPU":
@@ -152,6 +152,7 @@ class LlumnixRayDistributedExecutor(RayDistributedExecutor):
                     placement_group_capture_child_tasks=True,
                     placement_group_bundle_index=dp_rank,
                 )
+                num_gpus = 1
                 if rank == 0:
                     num_gpus = NUM_GPUS_VLLM_V1_GPU_ACTOR
                 if current_platform.ray_device_key == "GPU":

--- a/llumnix/entrypoints/vllm_v1/api_server_actor.py
+++ b/llumnix/entrypoints/vllm_v1/api_server_actor.py
@@ -72,8 +72,9 @@ class APIServerActorVLLMV1(APIServerActor):
             setattr(serve_args, field.name, getattr(entrypoints_args, field.name))
         # NOTE(shejiarui): `speculative_config` has been set somewhere,
         # set it to `None` here to avoid exceptions.
-        if hasattr(serve_args, "speculative_config") and serve_args.speculative_config == {}:
-            serve_args.speculative_config = None
+        if hasattr(serve_args, "speculative_config") and serve_args.speculative_config is not None:
+            if len(serve_args.speculative_config) == 0:
+                serve_args.speculative_config = None
 
         # Set global variable in vLLM
         import vllm.v1.engine.core_client # pylint: disable=import-outside-toplevel

--- a/llumnix/entrypoints/vllm_v1/api_server_actor.py
+++ b/llumnix/entrypoints/vllm_v1/api_server_actor.py
@@ -72,7 +72,7 @@ class APIServerActorVLLMV1(APIServerActor):
             setattr(serve_args, field.name, getattr(entrypoints_args, field.name))
         # NOTE(shejiarui): `speculative_config` has been set somewhere,
         # set it to `None` here to avoid exceptions.
-        if hasattr(serve_args, "speculative_config"):
+        if hasattr(serve_args, "speculative_config") and serve_args.speculative_config == {}:
             serve_args.speculative_config = None
 
         # Set global variable in vLLM

--- a/llumnix/entrypoints/vllm_v1/arg_utils.py
+++ b/llumnix/entrypoints/vllm_v1/arg_utils.py
@@ -133,8 +133,9 @@ def detect_unsupported_engine_feature(engine_args: "EngineArgs") -> None:
         unsupported_feature = "automatic prefix caching"
     elif engine_args.enable_chunked_prefill:
         unsupported_feature = "chunked prefill"
-    elif engine_args.speculative_config:
-        unsupported_feature = "speculative decoding"
+    # NOTE(shejiarui): qwen3 test required speculative decoding.
+    # elif engine_args.speculative_config:
+    #     unsupported_feature = "speculative decoding"
     elif engine_args.pipeline_parallel_size > 1:
         unsupported_feature = "pipeline parallel"
     elif engine_args.num_scheduler_steps > 1:

--- a/llumnix/entrypoints/vllm_v1/arg_utils.py
+++ b/llumnix/entrypoints/vllm_v1/arg_utils.py
@@ -78,6 +78,8 @@ class VLLMV1EngineArgs(LlumnixEngineArgs):
     def _get_dp_args(self, engine_args: "AsyncEngineArgs"):
         dp_size = engine_args.data_parallel_size
         dp_size_local = engine_args.data_parallel_size_local
+        if dp_size_local is None:
+            dp_size_local = dp_size
         return dp_size, dp_size_local
 
     def _get_engine_args(self, engine_args: "AsyncEngineArgs"):

--- a/llumnix/entrypoints/vllm_v1/arg_utils.py
+++ b/llumnix/entrypoints/vllm_v1/arg_utils.py
@@ -190,7 +190,8 @@ def get_args(llumnix_config: LlumnixConfig, launch_mode: LaunchMode, parser: Llu
     post_init_llumnix_args(engine_args, instance_args, manager_args, entrypoints_args, BackendType.VLLM_V1, launch_mode, parser)
 
     # backend related check args
-    check_engine_args(engine_args)
+    if manager_args.enable_migration:
+        check_engine_args(engine_args)
     check_instance_args(instance_args, engine_args)
 
     logger.info("entrypoints_args: {}".format(entrypoints_args))

--- a/llumnix/entrypoints/vllm_v1/arg_utils.py
+++ b/llumnix/entrypoints/vllm_v1/arg_utils.py
@@ -61,7 +61,8 @@ class VLLMV1EngineArgs(LlumnixEngineArgs):
                  engine_args: "AsyncEngineArgs",
                  backend_type: BackendType = BackendType.VLLM_V1) -> None:
         self.world_size = self._get_world_size(engine_args)
-        self.dp_size, self.dp_size_local = self._get_dp_args(engine_args)
+        self.dp_size = self._get_dp_size(engine_args)
+        self.dp_size_local = self._get_dp_size_local(engine_args)
         super().__init__(
             engine_args=self._get_engine_args(engine_args),
             backend_type=backend_type
@@ -75,12 +76,15 @@ class VLLMV1EngineArgs(LlumnixEngineArgs):
         world_size = engine_args.pipeline_parallel_size * engine_args.tensor_parallel_size
         return world_size
 
-    def _get_dp_args(self, engine_args: "AsyncEngineArgs"):
+    def _get_dp_size(self, engine_args: "AsyncEngineArgs"):
         dp_size = engine_args.data_parallel_size
+        return dp_size
+
+    def _get_dp_size_local(self, engine_args: "AsyncEngineArgs"):
         dp_size_local = engine_args.data_parallel_size_local
         if dp_size_local is None:
-            dp_size_local = dp_size
-        return dp_size, dp_size_local
+            dp_size_local = engine_args.data_parallel_size
+        return dp_size_local
 
     def _get_engine_args(self, engine_args: "AsyncEngineArgs"):
         return pickle.dumps(engine_args)

--- a/llumnix/entrypoints/vllm_v1/arg_utils.py
+++ b/llumnix/entrypoints/vllm_v1/arg_utils.py
@@ -61,7 +61,7 @@ class VLLMV1EngineArgs(LlumnixEngineArgs):
                  engine_args: "AsyncEngineArgs",
                  backend_type: BackendType = BackendType.VLLM_V1) -> None:
         self.world_size = self._get_world_size(engine_args)
-        self.dp_size = self._get_dp_size(engine_args)
+        self.dp_size, self.dp_size_local = self._get_dp_args(engine_args)
         super().__init__(
             engine_args=self._get_engine_args(engine_args),
             backend_type=backend_type
@@ -75,9 +75,10 @@ class VLLMV1EngineArgs(LlumnixEngineArgs):
         world_size = engine_args.pipeline_parallel_size * engine_args.tensor_parallel_size
         return world_size
 
-    def _get_dp_size(self, engine_args: "AsyncEngineArgs"):
+    def _get_dp_args(self, engine_args: "AsyncEngineArgs"):
         dp_size = engine_args.data_parallel_size
-        return dp_size
+        dp_size_local = engine_args.data_parallel_size_local
+        return dp_size, dp_size_local
 
     def _get_engine_args(self, engine_args: "AsyncEngineArgs"):
         return pickle.dumps(engine_args)
@@ -97,6 +98,9 @@ class VLLMV1EngineArgs(LlumnixEngineArgs):
 
     def get_dp_size(self):
         return self.dp_size
+
+    def get_dp_size_local(self):
+        return self.dp_size_local
 
 
 @dataclass

--- a/llumnix/entrypoints/vllm_v1/dp_manager.py
+++ b/llumnix/entrypoints/vllm_v1/dp_manager.py
@@ -57,6 +57,7 @@ class DPManager:
         instance_id: str,
         instance_type: InstanceType,
         dp_size: int,
+        dp_size_local: int,
         instance_id_list: List[str],
         entrypoints_args_list: List[EntrypointsArgs],
         instance_args_list: List[InstanceArgs],
@@ -68,6 +69,7 @@ class DPManager:
         self.instance_id = instance_id
         self.instance_type = instance_type
         self.dp_size = dp_size
+        self.dp_size_local = dp_size_local
         self.placement_group = placement_group
         self.scaler = scaler
         self.manager = manager
@@ -83,6 +85,7 @@ class DPManager:
         elif dp_group_status == DPGroupStatus.EMPTY:
             instances, servers = self._init_instances_and_servers(
                 dp_size,
+                dp_size_local,
                 instance_id_list,
                 entrypoints_args_list,
                 instance_args_list,
@@ -105,6 +108,7 @@ class DPManager:
         instance_id: str,
         instance_type: InstanceType,
         dp_size: int,
+        dp_size_local: int,
         instance_id_list: List[str],
         entrypoints_args_list: List[EntrypointsArgs],
         instance_args_list: List[InstanceArgs],
@@ -129,6 +133,7 @@ class DPManager:
             instance_id,
             instance_type,
             dp_size,
+            dp_size_local,
             instance_id_list,
             entrypoints_args_list,
             instance_args_list,
@@ -142,6 +147,7 @@ class DPManager:
     def _init_instances_and_servers(
         self,
         dp_size: int,
+        dp_size_local: int,
         instance_id_list: List[str],
         entrypoints_args_list: List[EntrypointsArgs],
         instance_args_list: List[InstanceArgs],
@@ -169,6 +175,8 @@ class DPManager:
                 dp_rank=rank,
                 dp_rank_local=dp_rank_local,
             )
+            dp_rank_local += 1
+            dp_rank_local %= dp_size_local
 
             server = APIServerActorVLLMV1.from_args(
                 NUM_GPUS_VLLM_V1_GPU_ACTOR,

--- a/llumnix/scaler.py
+++ b/llumnix/scaler.py
@@ -759,6 +759,7 @@ class Scaler:
                 self.inflight_num_decode_instances -= dp_size if instance_type == InstanceType.DECODE else 0
 
         dp_size = engine_args.get_dp_size()
+        dp_size_local = engine_args.get_dp_size_local()
 
         next_instance_type = self._get_next_instance_type(dp_size) if instance_type is None else instance_type
         instance_args.instance_type = next_instance_type
@@ -785,6 +786,7 @@ class Scaler:
             instance_id,
             next_instance_type,
             dp_size,
+            dp_size_local,
             instance_id_list,
             entrypoints_args_list,
             instance_args_list,


### PR DESCRIPTION
1. Executor will allocate NUM_GPUS_VLLM_V1_GPU_ACTOR GPU for every TP rank now and will cause runtime error. Fix it so that only TP rank0 will get NUM_GPUS_VLLM_V1_GPU_ACTOR GPU and other ranks will get 1 GPU.
2. Fix OutputForwarder bundle_index to dp_rank, default set to 0. 
3. Remove speculative decoding check when check args and add support for it in vLLM v1 backend. It may has no quality assurance for other backend.
4. Add dp_size_local for kvtbackend naming.
5. Fix kv_transfer_config maybe None.