### PR TITLE
Fix benchmark_serving.py: _latency_info.json accumulates across runs and silently drops data

### DIFF
--- a/benchmark/benchmark_serving.py
+++ b/benchmark/benchmark_serving.py
@@ -901,32 +901,20 @@ def main():
         return
 
     file_name = os.path.splitext(args.log_filename)[0] + "_latency_info.json"
-    results = []
-    import datetime
-    current_time = datetime.datetime.now().strftime("%Y-%m-%d_%H:%M:%S")
-    file_name = os.path.splitext(args.log_filename)[0] + "_latency_info.json"
-    try:
-        with open(file_name, 'r') as f:
-            results = json.load(f)
-    except json.decoder.JSONDecodeError:
-        pass
-    except FileNotFoundError:
-        os.mknod(file_name)
     with open(file_name, 'w') as f:
-        results.append({"qps": args.qps,
-                        "cv": args.coefficient_variation,
-                        "request_ids": request_ids,
-                        "request_lens": request_lens,
-                        "request_latencies": request_latencies,
-                        "prefill_token_latencies": prefill_token_latencies,
-                        "decode_token_latencies": decode_token_latencies,
-                        "decode_sum_latencies": decode_sum_latencies,
-                        "all_decode_token_latencies": all_decode_token_latencies,
-                        "inference_latencies": inference_latencies,
-                        "per_token_latency_breakdown_list": per_token_latency_breakdown_list,
-                        "throughput": throughput, 
-                        "instance_num": avg_instance_num})
-        json.dump(results, f)
+        json.dump([{"qps": args.qps,
+                    "cv": args.coefficient_variation,
+                    "request_ids": request_ids,
+                    "request_lens": request_lens,
+                    "request_latencies": request_latencies,
+                    "prefill_token_latencies": prefill_token_latencies,
+                    "decode_token_latencies": decode_token_latencies,
+                    "decode_sum_latencies": decode_sum_latencies,
+                    "all_decode_token_latencies": all_decode_token_latencies,
+                    "inference_latencies": inference_latencies,
+                    "per_token_latency_breakdown_list": per_token_latency_breakdown_list,
+                    "throughput": throughput,
+                    "instance_num": avg_instance_num}], f)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem

In `benchmark/benchmark_serving.py`, `main()` writes per-run results to `<log_filename>_latency_info.json` by **loading any existing file and appending** the current run:

```python
results = []
...
try:
    with open(file_name, 'r') as f:
        results = json.load(f)
except FileNotFoundError:
    os.mknod(file_name)
with open(file_name, 'w') as f:
    results.append({... this run ...})
    json.dump(results, f)
```

Three issues:

1. **Silent data accumulation / loss on filename reuse.** Re-running with the same `--log_filename` grows the JSON list across runs. Consumers that read `json.load(f)[0]` then read the *oldest* run and silently drop the current one.
2. **`os.mknod` is not portable** (absent on Windows, restricted on macOS) so the `FileNotFoundError` path crashes there — and it is redundant, since the following `open(file_name, 'w')` already creates the file.
3. **Dead code**: a duplicated `file_name = ...` assignment and an unused `current_time` / `import datetime`.

## Fix

Write the current run as the sole element of a one-element list with a plain `open(..., 'w')`:

```python
file_name = os.path.splitext(args.log_filename)[0] + "_latency_info.json"
with open(file_name, 'w') as f:
    json.dump([{... this run ...}], f)
```

This preserves the on-disk structure (a list whose `[0]` holds the run's metrics, so existing `[0]` consumers keep working), makes each run write exactly its own data, and removes the non-portable `os.mknod` and the dead lines. No change for a fresh filename; reusing a filename now overwrites instead of silently accumulating.